### PR TITLE
Fixing wrong ROS Unit API

### DIFF
--- a/mg400_control/include/mg400_control/mg400_interface/commander.hpp
+++ b/mg400_control/include/mg400_control/mg400_interface/commander.hpp
@@ -141,5 +141,15 @@ private:
   {
     return deg * M_PI / 180.0;
   }
+
+  static inline double mm2m(double unit_mm)
+  {
+    return unit_mm * 1e-3;
+  }
+
+  static inline double m2mm(double unit_m)
+  {
+    return unit_m * 1e-3;
+  }
 };
 }  // namespace mg400_interface

--- a/mg400_control/include/mg400_control/mg400_interface/commander.hpp
+++ b/mg400_control/include/mg400_control/mg400_interface/commander.hpp
@@ -125,6 +125,10 @@ public:
 
   void servoP(double, double, double, double, double, double);
 
+  void arc(double, double, double, double, double, double, double, double, double, double, double, double);
+
+  void circle(double, double, double, double, double, double, double, double, double, double, double, double);
+
   void dashSendCmd(const char *, uint32_t);
 
   void realSendCmd(const char *, uint32_t);
@@ -149,7 +153,7 @@ private:
 
   static inline double m2mm(double unit_m)
   {
-    return unit_m * 1e-3;
+    return unit_m * 1e3;
   }
 };
 }  // namespace mg400_interface

--- a/mg400_control/include/mg400_control/mg400_interface/commander.hpp
+++ b/mg400_control/include/mg400_control/mg400_interface/commander.hpp
@@ -125,9 +125,13 @@ public:
 
   void servoP(double, double, double, double, double, double);
 
-  void arc(double, double, double, double, double, double, double, double, double, double, double, double);
+  void arc(
+    double, double, double, double, double, double, double, double, double, double, double,
+    double);
 
-  void circle(double, double, double, double, double, double, double, double, double, double, double, double);
+  void circle(
+    double, double, double, double, double, double, double, double, double, double,
+    double, double);
 
   void dashSendCmd(const char *, uint32_t);
 

--- a/mg400_control/src/mg400_control/component.cpp
+++ b/mg400_control/src/mg400_control/component.cpp
@@ -1048,17 +1048,11 @@ void Component::arc(
 {
   (void)request_header;  // for linter
   try {
-    char cmd[100];
-    snprintf(
-      cmd,
-      sizeof(cmd),
-      "Arc(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,"
-      "%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
+    this->commander_->arc(
       request->x1, request->y1, request->z1,
       request->rx1, request->ry1, request->rz1,
       request->x2, request->y2, request->z2,
       request->rx2, request->ry2, request->rz2);
-    this->commander_->realSendCmd(cmd, strlen(cmd));
     response->res = 0;
   } catch (const mg400_interface::TcpClientException & e) {
     RCLCPP_ERROR(
@@ -1076,19 +1070,11 @@ void Component::circle(
 {
   (void)request_header;  // for linter
   try {
-    char cmd[100];
-    snprintf(
-      cmd,
-      sizeof(cmd),
-      "Circle(%d, "
-      "%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,"
-      "%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
-      request->count,
+    this->commander_->circle(
       request->x1, request->y1, request->z1,
       request->rx1, request->ry1, request->rz1,
       request->x2, request->y2, request->z2,
       request->rx2, request->ry2, request->rz2);
-    this->commander_->realSendCmd(cmd, strlen(cmd));
     response->res = 0;
   } catch (const mg400_interface::TcpClientException & e) {
     RCLCPP_ERROR(

--- a/mg400_control/src/mg400_interface/commander.cpp
+++ b/mg400_control/src/mg400_interface/commander.cpp
@@ -274,7 +274,8 @@ void Commander::relMovJ(
 void Commander::relMovL(double x, double y, double z)
 {
   char cmd[100];
-  snprintf(cmd, sizeof(cmd), "RelMovL(%0.3f,%0.3f,%0.3f)",
+  snprintf(
+    cmd, sizeof(cmd), "RelMovL(%0.3f,%0.3f,%0.3f)",
     this->m2mm(x),
     this->m2mm(y),
     this->m2mm(z));

--- a/mg400_control/src/mg400_interface/commander.cpp
+++ b/mg400_control/src/mg400_interface/commander.cpp
@@ -169,24 +169,50 @@ void Commander::movJ(double x, double y, double z, double a, double b, double c)
   snprintf(
     cmd, sizeof(cmd),
     "MovJ(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
-    this->m2mm(z),
     this->m2mm(x),
     this->m2mm(y),
+    this->m2mm(z),
     this->rad2Deg(a),
     this->rad2Deg(b),
     this->rad2Deg(c));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
+/**
+ * @brief Linear movement, the target point is Cartesan point
+ *
+ * @param x X-axis coordinates, unit: m
+ * @param y Y-axis coordinates, unit: m
+ * @param z Z-axis coordinates, unit: m
+ * @param a A-axis coordinates, unit: rad
+ * @param b B-axis coordinates, unit: rad
+ * @param c C-axis coordinates, unit: rad
+ */
 void Commander::movL(double x, double y, double z, double a, double b, double c)
 {
   char cmd[100];
   snprintf(
     cmd, sizeof(cmd),
-    "MovL(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)", x, y, z, a, b, c);
+    "MovL(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
+    this->m2mm(x),
+    this->m2mm(y),
+    this->m2mm(z),
+    this->rad2Deg(a),
+    this->rad2Deg(b),
+    this->rad2Deg(c));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
+/**
+ * @brief Point to point movement, the target point is joint point
+ *
+ * @param j1 J1 coordinates, unit: rad
+ * @param j2 J2 coordinates, unit: rad
+ * @param j3 J3 coordinates, unit: rad
+ * @param j4 J4 coordinates, unit: rad
+ * @param j5 J5 coordinates, unit: rad
+ * @param j6 J6 coordinates, unit: rad
+ */
 void Commander::jointMovJ(
   double j1, double j2, double j3,
   double j4, double j5, double j6)
@@ -195,7 +221,12 @@ void Commander::jointMovJ(
   snprintf(
     cmd, sizeof(cmd),
     "JointMovJ(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
-    j1, j2, j3, j4, j5, j6);
+    this->rad2Deg(j1),
+    this->rad2Deg(j2),
+    this->rad2Deg(j3),
+    this->rad2Deg(j4),
+    this->rad2Deg(j5),
+    this->rad2Deg(j6));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
@@ -206,7 +237,16 @@ void Commander::moveJog(const std::string & axis)
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
-
+/**
+ * @brief Relative motion is performed along the tool coordinate system, and the end motion is joint motion
+ *
+ * @param offset1 X-axis coordinates, unit: m
+ * @param offset2 Y-axis coordinates, unit: m
+ * @param offset3 Z-axis coordinates, unit: m
+ * @param offset4 A-axis coordinates, unit: rad
+ * @param offset5 B-axis coordinates, unit: rad
+ * @param offset6 C-axis coordinates, unit: rad
+ */
 void Commander::relMovJ(
   double offset1, double offset2, double offset3,
   double offset4, double offset5, double offset6)
@@ -215,18 +255,42 @@ void Commander::relMovJ(
   snprintf(
     cmd, sizeof(cmd),
     "RelMovJ(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
-    offset1, offset2, offset3,
-    offset4, offset5, offset6);
+    this->m2mm(offset1),
+    this->m2mm(offset2),
+    this->m2mm(offset3),
+    this->rad2Deg(offset4),
+    this->rad2Deg(offset5),
+    this->rad2Deg(offset6));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
+/**
+ * @brief Relative motion is performed along the tool coordinate system, and the end motion is linear motion
+ *
+ * @param x X-axis coordinates, unit: m
+ * @param y Y-axis coordinates, unit: m
+ * @param z Z-axis coordinates, unit: m
+ */
 void Commander::relMovL(double x, double y, double z)
 {
   char cmd[100];
-  snprintf(cmd, sizeof(cmd), "RelMovL(%0.3f,%0.3f,%0.3f)", x, y, z);
+  snprintf(cmd, sizeof(cmd), "RelMovL(%0.3f,%0.3f,%0.3f)",
+    this->m2mm(x),
+    this->m2mm(y),
+    this->m2mm(z));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
+/**
+ * @brief Dynamic following command based on joint space
+ *
+ * @param j1 J1 coordinates, unit: rad
+ * @param j2 J2 coordinates, unit: rad
+ * @param j3 J3 coordinates, unit: rad
+ * @param j4 J4 coordinates, unit: rad
+ * @param j5 J5 coordinates, unit: rad
+ * @param j6 J6 coordinates, unit: rad
+ */
 void Commander::servoJ(
   double j1, double j2, double j3,
   double j4, double j5, double j6)
@@ -235,10 +299,25 @@ void Commander::servoJ(
   snprintf(
     cmd, sizeof(cmd),
     "ServoJ(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
-    j1, j2, j3, j4, j5, j6);
+    this->rad2Deg(j1),
+    this->rad2Deg(j2),
+    this->rad2Deg(j3),
+    this->rad2Deg(j4),
+    this->rad2Deg(j5),
+    this->rad2Deg(j6));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 
+/**
+ * @brief Dynamic following command based on Cartesian space
+ *
+ * @param x X-axis coordinates, unit: m
+ * @param y Y-axis coordinates, unit: m
+ * @param z Z-axis coordinates, unit: m
+ * @param a A-axis coordinates, unit: rad
+ * @param b B-axis coordinates, unit: rad
+ * @param c C-axis coordinates, unit: rad
+ */
 void Commander::servoP(
   double x, double y, double z,
   double a, double b, double c)
@@ -247,7 +326,94 @@ void Commander::servoP(
   snprintf(
     cmd, sizeof(cmd),
     "ServoP(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
-    x, y, z, a, b, c);
+    this->m2mm(x),
+    this->m2mm(y),
+    this->m2mm(z),
+    this->rad2Deg(a),
+    this->rad2Deg(b),
+    this->rad2Deg(c));
+  this->real_time_tcp_->send(cmd, strlen(cmd));
+}
+
+/**
+ * @brief Move from the current position to a target position in an arc interpolated mode under the Cartesian coordinate system
+ *
+ * @param x1 X-axis coordinates, unit: m
+ * @param y1 Y-axis coordinates, unit: m
+ * @param z1 Z-axis coordinates, unit: m
+ * @param rx1 X-axis coordinates, unit: rad
+ * @param ry1 Y-axis coordinates, unit: rad
+ * @param rz1 Z-axis coordinates, unit: rad
+ * @param x2 X-axis coordinates, unit: m
+ * @param y2 Y-axis coordinates, unit: m
+ * @param z2 Z-axis coordinates, unit: m
+ * @param rx2 X-axis coordinates, unit: rad
+ * @param ry2 Y-axis coordinates, unit: rad
+ * @param rz2 Z-axis coordinates, unit: rad
+ */
+void Commander::arc(
+  double x1, double y1, double z1,
+  double rx1, double ry1, double rz1,
+  double x2, double y2, double z2,
+  double rx2, double ry2, double rz2)
+{
+  char cmd[100];
+  snprintf(
+    cmd, sizeof(cmd),
+    "Arc(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
+    this->m2mm(x1),
+    this->m2mm(y1),
+    this->m2mm(z1),
+    this->rad2Deg(rx1),
+    this->rad2Deg(ry1),
+    this->rad2Deg(rz1),
+    this->m2mm(x2),
+    this->m2mm(y2),
+    this->m2mm(z2),
+    this->rad2Deg(rx2),
+    this->rad2Deg(ry2),
+    this->rad2Deg(rz2));
+  this->real_time_tcp_->send(cmd, strlen(cmd));
+}
+
+/**
+ * @brief Move from the current position to a target position in an circle interpolated mode under the Cartesian coordinate system
+ *
+ * @param x1 X-axis coordinates, unit: m
+ * @param y1 Y-axis coordinates, unit: m
+ * @param z1 Z-axis coordinates, unit: m
+ * @param rx1 X-axis coordinates, unit: rad
+ * @param ry1 Y-axis coordinates, unit: rad
+ * @param rz1 Z-axis coordinates, unit: rad
+ * @param x2 X-axis coordinates, unit: m
+ * @param y2 Y-axis coordinates, unit: m
+ * @param z2 Z-axis coordinates, unit: m
+ * @param rx2 X-axis coordinates, unit: rad
+ * @param ry2 Y-axis coordinates, unit: rad
+ * @param rz2 Z-axis coordinates, unit: rad
+ */
+void Commander::circle(
+  double x1, double y1, double z1,
+  double rx1, double ry1, double rz1,
+  double x2, double y2, double z2,
+  double rx2, double ry2, double rz2)
+{
+  char cmd[100];
+  snprintf(
+    cmd, sizeof(cmd),
+    "Circle(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
+    this->m2mm(x1),
+    this->m2mm(y1),
+    this->m2mm(z1),
+    this->rad2Deg(rx1),
+    this->rad2Deg(ry1),
+    this->rad2Deg(rz1),
+    this->m2mm(x2),
+    this->m2mm(y2),
+    this->m2mm(z2),
+    this->rad2Deg(rx2),
+    this->rad2Deg(ry2),
+    this->rad2Deg(rz2));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 

--- a/mg400_control/src/mg400_interface/commander.cpp
+++ b/mg400_control/src/mg400_interface/commander.cpp
@@ -153,12 +153,28 @@ void Commander::speedFactor(int ratio)
   this->dash_board_tcp_->send(cmd, strlen(cmd));
 }
 
+/**
+ * @brief Point to point movement, the target point is Cartesan point
+ *
+ * @param x X-axis coordinates, unit: m
+ * @param y Y-axis coordinates, unit: m
+ * @param z Z-axis coordinates, unit: m
+ * @param a A-axis coordinates, unit: rad
+ * @param b B-axis coordinates, unit: rad
+ * @param c C-axis coordinates, unit: rad
+ */
 void Commander::movJ(double x, double y, double z, double a, double b, double c)
 {
   char cmd[100];
   snprintf(
     cmd, sizeof(cmd),
-    "MovJ(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)", x, y, z, a, b, c);
+    "MovJ(%0.3f,%0.3f,%0.3f,%0.3f,%0.3f,%0.3f)",
+    this->m2mm(z),
+    this->m2mm(x),
+    this->m2mm(y),
+    this->rad2Deg(a),
+    this->rad2Deg(b),
+    this->rad2Deg(c));
   this->real_time_tcp_->send(cmd, strlen(cmd));
 }
 

--- a/sample.bash
+++ b/sample.bash
@@ -9,18 +9,19 @@ ros2 service call /mg400/enable_robot mg400_msgs/srv/EnableRobot
 # Move
 ## Roll
 ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
-  "{x: 340.0, y: 0.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+  "{x: 0.34, y: 0.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
 ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
-  "{x: 0.0, y: -340.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+  "{x: 0.0, y: -0.34, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
 ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
-  "{x: 340.0, y: 0.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+  "{x: 0.34, y: 0.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
 
 ros2 service call /mg400/mov_l mg400_msgs/srv/MovL \
-  "{x: 200.0, y: 50.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+  "{x: 0.2, y: 0.05, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
 ros2 service call /mg400/mov_l mg400_msgs/srv/MovL \
-  "{x: 400.0, y: -50.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+  "{x: 0.4, y: -0.05, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
 ros2 service call /mg400/mov_l mg400_msgs/srv/MovL \
-  "{x: 340.0, y: 0.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+  "{x: 0.34, y: 0.0, z: 0.0, a: 0.0, b: 0.0, c: 0.0}"
+ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
 
 sleep 1
 


### PR DESCRIPTION
## About
Fix following unit on the service
 - `mm` -> `m`
 -  `deg` -> `rad`


- [x] movJ
- [x] movL
- [x] RelMovL
- [x] RelMovJ
- [x] JointMovJ
- [x] Arc
- [x] Circle
- [x] ServoJ
- [x] ServoP