### PR TITLE
WIP:MovJ wait response for motion completed.

### DIFF
--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -103,6 +103,9 @@ void RealtimeFeedbackTcpInterface::recvData()
             this->current_joints_[i] =
               this->rt_data_.q_actual[i] * TO_RADIAN;
           }
+          RCLCPP_INFO(
+            this->getLogger(), "Robot mode is %ld",
+            RealtimeFeedbackTcpInterface::getRobotMode());
           this->mutex_.unlock();
           continue;
         } else {

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -104,8 +104,8 @@ void RealtimeFeedbackTcpInterface::recvData()
               this->rt_data_.q_actual[i] * TO_RADIAN;
           }
           RCLCPP_INFO(
-            this->getLogger(), "Robot mode is %ld",
-            RealtimeFeedbackTcpInterface::getRobotMode());
+            this->getLogger(), "Robot mode is %d",
+            static_cast<int>(RealtimeFeedbackTcpInterface::getRobotMode()));
           this->mutex_.unlock();
           continue;
         } else {

--- a/mg400_node/include/mg400_node/service_node.hpp
+++ b/mg400_node/include/mg400_node/service_node.hpp
@@ -58,6 +58,8 @@ private:
 
   std::unique_ptr<mg400_interface::MG400Interface> interface_;
 
+  rclcpp::CallbackGroup::SharedPtr joint_cb_group_;
+  rclcpp::CallbackGroup::SharedPtr service_cb_group_;
   rclcpp::TimerBase::SharedPtr js_timer_;
   rclcpp::TimerBase::SharedPtr error_timer_;
 

--- a/mg400_node/src/service_node.cpp
+++ b/mg400_node/src/service_node.cpp
@@ -418,6 +418,14 @@ void ServiceNode::movJ(
   this->interface_->motion_commander->movJ(
     request->x, request->y, request->z,
     request->rx, request->ry, request->rz);
+  using namespace std::chrono_literals;
+  rclcpp::sleep_for(30ms);
+  while (this->rt_tcp_if_->getRobotMode() != mg400_interface::RobotMode::ENABLE) {
+    RCLCPP_INFO(
+      this->get_logger(), "Waiting for motion completed."
+    );
+    rclcpp::sleep_for(10ms);
+  }
 }
 
 void ServiceNode::movL(

--- a/mg400_node/src/service_node.cpp
+++ b/mg400_node/src/service_node.cpp
@@ -420,7 +420,9 @@ void ServiceNode::movJ(
     request->rx, request->ry, request->rz);
   using namespace std::chrono_literals;
   rclcpp::sleep_for(30ms);
-  while (this->rt_tcp_if_->getRobotMode() != mg400_interface::RobotMode::ENABLE) {
+  while (this->interface_->realtime_tcp_interface->getRobotMode() !=
+    mg400_interface::RobotMode::ENABLE)
+  {
     RCLCPP_INFO(
       this->get_logger(), "Waiting for motion completed."
     );


### PR DESCRIPTION
MovJ実行時に，目標地点到達までブロッキング処理を行う．

Known ISSUE:
サービス呼び出し時に，目標地点到達までブロッキングを行うとJointStateの更新が止まるので別スレッドでサービスを裁かなければならない．