### PR TITLE
fix service msg

### DIFF
--- a/mg400_msgs/srv/MovJ.srv
+++ b/mg400_msgs/srv/MovJ.srv
@@ -1,7 +1,5 @@
 float64 x
 float64 y
 float64 z
-float64 rx
-float64 ry
-float64 rz
+float64 r
 ---

--- a/mg400_node/src/service_node.cpp
+++ b/mg400_node/src/service_node.cpp
@@ -433,7 +433,7 @@ void ServiceNode::movJ(
 {
   this->interface_->motion_commander->movJ(
     request->x, request->y, request->z,
-    request->rx, request->ry, request->rz);
+    request->r, 0.0, 0.0);
 }
 
 void ServiceNode::movL(

--- a/sample.bash
+++ b/sample.bash
@@ -9,20 +9,13 @@ ros2 service call /mg400/enable_robot mg400_msgs/srv/EnableRobot
 # Move
 ## Roll
 ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
-  "{x: 0.34, y: 0.0, z: 0.0, rx: 0.0, ry: 0.0, rz: 0.0}"
+  "{x: 0.34, y: 0.0, z: 0.0, r: 0.0}"
 ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
-  "{x: 0.0, y: -0.34, z: 0.0, rx: 0.0, ry: 0.0, rz: 0.0}"
+  "{x: 0.0, y: -0.34, z: 0.0, r: 1.57}"
 ros2 service call /mg400/mov_j mg400_msgs/srv/MovJ \
-  "{x: 0.34, y: 0.0, z: 0.0, rx: 0.0, ry: 0.0, rz: 0.0}"
+  "{x: 0.34, y: 0.0, z: 0.0, r: 0.0}"
 
-ros2 service call /mg400/mov_l mg400_msgs/srv/MovL \
-  "{x: 0.2, y: 0.05, z: 0.0, rx: 0.0, ry: 0.0, rz: 0.0}"
-ros2 service call /mg400/mov_l mg400_msgs/srv/MovL \
-  "{x: 0.4, y: -0.05, z: 0.0, rx: 0.0, ry: 0.0, rz: 0.0}"
-ros2 service call /mg400/mov_l mg400_msgs/srv/MovL \
-  "{x: 0.34, y: 0.0, z: 0.0, rx: 0.0, ry: 0.0, rz: 0.0}"
-
-sleep 1
+sleep 5
 
 # Turn off
 ros2 service call /mg400/disable_robot mg400_msgs/srv/DisableRobot


### PR DESCRIPTION
Current movJ service takes 6 arguments, but dobot_mg400 only takes first 4 arguments.
So fixing service command to avoid ambiguity.


### Before
```
 float64 x
float64 y
float64 z
float64 rx
float64 ry
float64 rz
```

### After
```
float64 x
float64 y
float64 z
float64 r
```