### PR TITLE
add build script for action

### DIFF
--- a/mg400_msgs/CMakeLists.txt
+++ b/mg400_msgs/CMakeLists.txt
@@ -6,35 +6,38 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # Find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+set(msg_files
+  "msg/RobotMode.msg")
 
 set(srv_files
-    "srv/AccJ.srv"
-    "srv/AccL.srv"
-    "srv/ClearError.srv"
-    "srv/DisableRobot.srv"
-    "srv/EnableRobot.srv"
-    "srv/JointMovJ.srv"
-    "srv/MoveJog.srv"
-    "srv/MovJ.srv"
-    "srv/MovL.srv"
-    "srv/ResetRobot.srv"
-    "srv/SpeedFactor.srv"
-    "srv/SpeedJ.srv"
-    "srv/SpeedL.srv"
-    "srv/Tool.srv"
-    "srv/ToolDOExecute.srv"
-)
+  "srv/AccJ.srv"
+  "srv/AccL.srv"
+  "srv/ClearError.srv"
+  "srv/DisableRobot.srv"
+  "srv/EnableRobot.srv"
+  "srv/JointMovJ.srv"
+  "srv/MoveJog.srv"
+  "srv/MovJ.srv"
+  "srv/MovL.srv"
+  "srv/ResetRobot.srv"
+  "srv/SpeedFactor.srv"
+  "srv/SpeedJ.srv"
+  "srv/SpeedL.srv"
+  "srv/Tool.srv"
+  "srv/ToolDOExecute.srv")
 
-set(msg_files "msg/RobotMode.msg")
+set(action_files
+  "action/MovJ.action")
 
 rosidl_generate_interfaces(
-  ${PROJECT_NAME} ${srv_files} ${msg_files} DEPENDENCIES builtin_interfaces
-  std_msgs
-)
+  ${PROJECT_NAME}
+    ${msg_files}
+    ${srv_files}
+    ${action_files}
+  DEPENDENCIES builtin_interfaces std_msgs)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -43,5 +46,4 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(rosidl_default_runtime)
-ament_package()
+ament_auto_package()

--- a/mg400_msgs/package.xml
+++ b/mg400_msgs/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>


### PR DESCRIPTION
Add patch for #104.

Added some build script.


After this change, you can see the custom action can be built and you can check all available ros2 interface via
```bash
ros2 interface list
```

Then you can find this action msgs is successfully built
```bash
ros2 interface list | grep action/MovJ
```
