### PR TITLE
fix setup sript to get all essential resources

### DIFF
--- a/mg400_bringup/package.xml
+++ b/mg400_bringup/package.xml
@@ -7,11 +7,13 @@
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache License 2.0</license>
 
-  <depend>rviz2</depend>
-  <depend>robot_state_publisher</depend>
-
-  <exec_depend>xacro</exec_depend>
   <exec_depend>joy</exec_depend>
+  <exec_depend>mg400_description</exec_depend>
+  <exec_depend>mg400_joy</exec_depend>
+  <exec_depend>mg400_node</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/setup.bash
+++ b/setup.bash
@@ -6,18 +6,20 @@ THIS_REPOSITORY_NAME="mg400"
 
 # Install ROS2 dependency
 ## From git repos
-colcon_ws=${THIS_PROJECT_ROOT}/../../
-cd ${colcon_ws}/src
-vcs import --recursive <${THIS_PROJECT_ROOT}/${THIS_REPOSITORY_NAME}.repos
-unset colcon_ws
+colcon_ws=$(realpath ${THIS_PROJECT_ROOT}/../../)
+
+vcs import \
+  --recursive \
+  --input ${THIS_PROJECT_ROOT}/${THIS_REPOSITORY_NAME}.repos \
+  ${colcon_ws}/src
+vcs pull ${colcon_ws}/src
 
 ## From apt repositories
 rosdep update
 rosdep install -r -y -i \
-  --from-paths ${THIS_PROJECT_ROOT} \
-  --rosdistro $ROS_DISTRO \
-  --skip-keys p9n_interface
+  --from-paths ${colcon_ws}/src \
+  --rosdistro $ROS_DISTRO
 
+unset colcon_ws
 unset THIS_FILE
 unset THIS_PROJECT_ROOT
-


### PR DESCRIPTION
Now
```bash
cd <projcetRoot>
./setup.bash
```
takes all dependencies in the workspace and pull dependent package update.