### PR TITLE
fix repository utl in mg400.repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y wget python3-vcstool python3-colcon-coveragepy-result
+      - name: SSH2HTTPS
+        run: sed -e 's/git@github.com:/https:\/\/github.com\//g' mg400.repos > tmp.repos
       - name: Build and Test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
@@ -40,4 +42,4 @@ jobs:
             mg400_msgs
             mg400_node
             mg400_joy
-          vcs-repo-file-url: mg400.repos
+          vcs-repo-file-url: tmp.repos

--- a/mg400.repos
+++ b/mg400.repos
@@ -1,5 +1,5 @@
 repositories:
   PlayStation-JoyInterface-ROS2:
     type: git
-    url: https://github.com/HarvestX/PlayStation-JoyInterface-ROS2.git
+    url: git@github.com:HarvestX/PlayStation-JoyInterface-ROS2.git
     version: main


### PR DESCRIPTION
This is just a small issue, but it seems like vcs thinks `https://github.com/HarvestX/PlayStation-JoyInterface-ROS2.git` is a different repository from `git@github.com:HarvestX/PlayStation-JoyInterface-ROS2.git`. And because other `.repos` use the latter, `mg400.repos` should also use the same url.