### PR TITLE
Fix mov_j timeout because of the flange orientation

### DIFF
--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -36,7 +36,8 @@ private:
     "mg400_plugin::EmergencyStop",
     "mg400_plugin::EnableRobot",
     "mg400_plugin::ResetRobot",
-    "mg400_plugin::SpeedFactor"
+    "mg400_plugin::SpeedFactor",
+    "mg400_plugin::ToolDOExecute"
   };
 
   const std::vector<std::string> default_motion_api_plugins_ = {

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
@@ -20,6 +20,7 @@
 #include <h6x_tf_handler/pose_tf_handler.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 namespace mg400_plugin
 {

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
@@ -20,7 +20,6 @@
 #include <h6x_tf_handler/pose_tf_handler.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 namespace mg400_plugin
 {

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -104,7 +104,7 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       return is_in_tolerance(pose.position.x - goal.position.x, tolerance_mm) &&
              is_in_tolerance(pose.position.y - goal.position.y, tolerance_mm) &&
              is_in_tolerance(pose.position.z - goal.position.z, tolerance_mm) &&
-             is_in_tolerance(pose.orientation.w - goal.orientation.w, tolerance_rad);
+             is_in_tolerance(tf2::getYaw(pose.orientation) - tf2::getYaw(goal.orientation), tolerance_rad);
     };
 
   const auto update_pose =
@@ -113,6 +113,21 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       msg.header.stamp = this->base_node_->get_clock()->now();
       msg.header.frame_id = this->realtime_tcp_interface_->frame_id_prefix + "mg400_origin_link";
       this->realtime_tcp_interface_->getCurrentEndPose(msg.pose);
+
+      // RealtimeFeedbackTcpInterface::getCurrentEndPose returns position based on 'mg400_origin_link'
+      // but the orientation is based on 'mg400_end_effector_flange'.
+      // Hence here we apply the rotation of 'mg400_end_effector_flange' to the returned value to make
+      // the orientation based on 'mg400_origin_link' as well.
+      auto flange_coord_rot = tf2::Quaternion();
+      flange_coord_rot.setRPY(0, 0, std::atan2(msg.pose.position.y, msg.pose.position.x));
+
+      auto flange_rot = tf2::Quaternion(msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w);
+      tf2::Quaternion rot_on_mg400_origin_link = flange_coord_rot * flange_rot;
+
+      msg.pose.orientation.x = rot_on_mg400_origin_link.x();
+      msg.pose.orientation.y = rot_on_mg400_origin_link.y();
+      msg.pose.orientation.z = rot_on_mg400_origin_link.z();
+      msg.pose.orientation.w = rot_on_mg400_origin_link.w();
     };
 
 

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -115,25 +115,6 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       msg.header.stamp = this->base_node_->get_clock()->now();
       msg.header.frame_id = this->realtime_tcp_interface_->frame_id_prefix + "mg400_origin_link";
       this->realtime_tcp_interface_->getCurrentEndPose(msg.pose);
-
-      // RealtimeFeedbackTcpInterface::getCurrentEndPose returns position based on 'mg400_origin_link'
-      // but the orientation is based on 'mg400_end_effector_flange'.
-      // Hence here we apply the rotation of 'mg400_end_effector_flange' to the returned value to make
-      // the orientation based on 'mg400_origin_link' as well.
-      auto flange_coord_rot = tf2::Quaternion();
-      flange_coord_rot.setRPY(0, 0, std::atan2(msg.pose.position.y, msg.pose.position.x));
-
-      auto flange_rot = tf2::Quaternion(
-        msg.pose.orientation.x,
-        msg.pose.orientation.y,
-        msg.pose.orientation.z,
-        msg.pose.orientation.w);
-      tf2::Quaternion rot_on_mg400_origin_link = flange_coord_rot * flange_rot;
-
-      msg.pose.orientation.x = rot_on_mg400_origin_link.x();
-      msg.pose.orientation.y = rot_on_mg400_origin_link.y();
-      msg.pose.orientation.z = rot_on_mg400_origin_link.z();
-      msg.pose.orientation.w = rot_on_mg400_origin_link.w();
     };
 
 

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -104,7 +104,9 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       return is_in_tolerance(pose.position.x - goal.position.x, tolerance_mm) &&
              is_in_tolerance(pose.position.y - goal.position.y, tolerance_mm) &&
              is_in_tolerance(pose.position.z - goal.position.z, tolerance_mm) &&
-             is_in_tolerance(tf2::getYaw(pose.orientation) - tf2::getYaw(goal.orientation), tolerance_rad);
+             is_in_tolerance(
+        tf2::getYaw(pose.orientation) - tf2::getYaw(goal.orientation),
+        tolerance_rad);
     };
 
   const auto update_pose =
@@ -121,7 +123,11 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       auto flange_coord_rot = tf2::Quaternion();
       flange_coord_rot.setRPY(0, 0, std::atan2(msg.pose.position.y, msg.pose.position.x));
 
-      auto flange_rot = tf2::Quaternion(msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w);
+      auto flange_rot = tf2::Quaternion(
+        msg.pose.orientation.x,
+        msg.pose.orientation.y,
+        msg.pose.orientation.z,
+        msg.pose.orientation.w);
       tf2::Quaternion rot_on_mg400_origin_link = flange_coord_rot * flange_rot;
 
       msg.pose.orientation.x = rot_on_mg400_origin_link.x();


### PR DESCRIPTION
This pull request fixes two points

1. compare `tf2::getYaw(pose.orientation)` and `tf2::getYaw(goal.orientation)` to evaluate how much the current flange orientation is distant from the goal.
2. fix orientation value of the current flange
    - As I wrote on the code, `RealtimeFeedbackTcpInterface::getCurrentEndPose` returns the position of `mg400_origin_link` but its orientation is actually based on `mg400_end_effector_flange`. Hence I've converted the value from that of `mg400_end_effector_flange` to `mg400_origin_link`.