### PR TITLE
Add ToolDOExecute plugin to the default list

### DIFF
--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -36,7 +36,8 @@ private:
     "mg400_plugin::EmergencyStop",
     "mg400_plugin::EnableRobot",
     "mg400_plugin::ResetRobot",
-    "mg400_plugin::SpeedFactor"
+    "mg400_plugin::SpeedFactor",
+    "mg400_plugin::ToolDOExecute"
   };
 
   const std::vector<std::string> default_motion_api_plugins_ = {


### PR DESCRIPTION
Although [mg400_node's README](https://github.com/HarvestX/MG400_ROS2/tree/humble/mg400_node) says the default plugins contain `ToolDOExecute`, it was actually not included. Hence I've added it to the list.