### PR TITLE
Fix atomic bool operation in TCP interface

### DIFF
--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -20,8 +20,9 @@ namespace mg400_interface
 RealtimeFeedbackTcpInterface::RealtimeFeedbackTcpInterface(
   const std::string & ip, const std::string & prefix)
 : frame_id_prefix(prefix),
-  current_joints_{}, rt_data_{}, is_running_(false)
+  current_joints_{}, rt_data_{}
 {
+  this->is_running_.store(false);
   this->tcp_socket_ = std::make_shared<TcpSocketHandler>(ip, this->PORT_);
 }
 
@@ -33,7 +34,7 @@ RealtimeFeedbackTcpInterface::~RealtimeFeedbackTcpInterface()
 void RealtimeFeedbackTcpInterface::init() noexcept
 {
   try {
-    this->is_running_ = true;
+    this->is_running_.store(true);
     this->thread_ = std::make_unique<std::thread>(&RealtimeFeedbackTcpInterface::recvData, this);
   } catch (const TcpSocketException & err) {
     RCLCPP_ERROR(this->getLogger(), "%s", err.what());
@@ -81,7 +82,7 @@ bool RealtimeFeedbackTcpInterface::isRobotMode(const uint64_t & expected_mode) c
 
 void RealtimeFeedbackTcpInterface::disConnect()
 {
-  this->is_running_ = false;
+  this->is_running_.store(false);
   if (this->thread_->joinable()) {
     this->thread_->join();
   }
@@ -95,7 +96,7 @@ void RealtimeFeedbackTcpInterface::recvData()
   using namespace std::chrono_literals;  // NOLINT
   int failed_cnd = 0;
   while (failed_cnd < CONNECTION_TRIAL) {
-    if (!this->is_running_) {
+    if (!this->is_running_.load()) {
       return;
     }
     try {
@@ -133,7 +134,7 @@ void RealtimeFeedbackTcpInterface::recvData()
   }
 
   RCLCPP_ERROR(this->getLogger(), "Failed more than %d times.. . Close connection.", failed_cnd);
-  this->is_running_ = false;
+  this->is_running_.store(false);
 }
 
 }  // namespace mg400_interface


### PR DESCRIPTION
In previous implementation, variables of the type of `std::atomic<bool>` were not used in the thread safe way but instead used just like the ordinary bool variables. This can prevent the program from stopping tcp interface from the main thread. This pull request fixes this problem.