### PR TITLE
Keep running mg400 node even when mg400 is not present or disconnected

### DIFF
--- a/mg400_interface/example/show_realtime_data.cpp
+++ b/mg400_interface/example/show_realtime_data.cpp
@@ -40,8 +40,9 @@ int main(int argc, char ** argv)
   }
 
   while (true) {
-    auto data = std::make_unique<mg400_interface::RealTimeData>(
-      rt_tcp_if->getRealtimeData());
+    auto data = rt_tcp_if->getRealtimeData();
+    if (!data) continue;
+
     auto tmp = std::system("clear");
     (void)tmp;  // for compiler warning
 

--- a/mg400_interface/example/show_realtime_data.cpp
+++ b/mg400_interface/example/show_realtime_data.cpp
@@ -41,7 +41,7 @@ int main(int argc, char ** argv)
 
   while (true) {
     auto data = rt_tcp_if->getRealtimeData();
-    if (!data) {continue};
+    if (!data) {continue;}
 
     auto tmp = std::system("clear");
     (void)tmp;  // for compiler warning

--- a/mg400_interface/example/show_realtime_data.cpp
+++ b/mg400_interface/example/show_realtime_data.cpp
@@ -41,7 +41,7 @@ int main(int argc, char ** argv)
 
   while (true) {
     auto data = rt_tcp_if->getRealtimeData();
-    if (!data) continue;
+    if (!data) {continue};
 
     auto tmp = std::system("clear");
     (void)tmp;  // for compiler warning

--- a/mg400_interface/include/mg400_interface/mg400_interface.hpp
+++ b/mg400_interface/include/mg400_interface/mg400_interface.hpp
@@ -61,5 +61,6 @@ public:
 
 private:
   static const rclcpp::Logger getLogger() noexcept;
+  bool isConnected();
 };
 }  // namespace mg400_interface

--- a/mg400_interface/include/mg400_interface/mg400_interface.hpp
+++ b/mg400_interface/include/mg400_interface/mg400_interface.hpp
@@ -57,6 +57,7 @@ public:
 
   bool activate();
   bool deactivate();
+  bool ok();
 
 private:
   static const rclcpp::Logger getLogger() noexcept;

--- a/mg400_interface/include/mg400_interface/tcp_interface/realtime_feedback_tcp_interface.hpp
+++ b/mg400_interface/include/mg400_interface/tcp_interface/realtime_feedback_tcp_interface.hpp
@@ -56,6 +56,7 @@ public:
 
   static rclcpp::Logger getLogger();
   bool isConnected();
+  bool isActive();
 
   void getCurrentJointStates(std::array<double, 4> &);
   void getCurrentEndPose(Pose &);

--- a/mg400_interface/include/mg400_interface/tcp_interface/realtime_feedback_tcp_interface.hpp
+++ b/mg400_interface/include/mg400_interface/tcp_interface/realtime_feedback_tcp_interface.hpp
@@ -41,7 +41,7 @@ private:
 
   std::mutex mutex_;
   std::array<double, 4> current_joints_;
-  RealTimeData rt_data_;
+  std::shared_ptr<RealTimeData> rt_data_;
   std::atomic<bool> is_running_;
   std::unique_ptr<std::thread> thread_;
   std::shared_ptr<TcpSocketHandler> tcp_socket_;
@@ -58,8 +58,8 @@ public:
 
   void getCurrentJointStates(std::array<double, 4> &);
   void getCurrentEndPose(Pose &);
-  RealTimeData getRealtimeData();
-  uint64_t getRobotMode();
+  std::shared_ptr<RealTimeData> getRealtimeData();
+  bool getRobotMode(uint64_t &);
   bool isRobotMode(const uint64_t &) const;
   void disConnect();
 

--- a/mg400_interface/include/mg400_interface/tcp_interface/realtime_feedback_tcp_interface.hpp
+++ b/mg400_interface/include/mg400_interface/tcp_interface/realtime_feedback_tcp_interface.hpp
@@ -39,7 +39,8 @@ private:
   using Pose = geometry_msgs::msg::Pose;
   const uint16_t PORT_ = 30004;
 
-  std::mutex mutex_;
+  std::mutex mutex_current_joints_;
+  std::mutex mutex_rt_data_;
   std::array<double, 4> current_joints_;
   std::shared_ptr<RealTimeData> rt_data_;
   std::atomic<bool> is_running_;
@@ -60,7 +61,7 @@ public:
   void getCurrentEndPose(Pose &);
   std::shared_ptr<RealTimeData> getRealtimeData();
   bool getRobotMode(uint64_t &);
-  bool isRobotMode(const uint64_t &) const;
+  bool isRobotMode(const uint64_t &);
   void disConnect();
 
 private:

--- a/mg400_interface/include/mg400_interface/tcp_interface/tcp_socket_handler.hpp
+++ b/mg400_interface/include/mg400_interface/tcp_interface/tcp_socket_handler.hpp
@@ -51,7 +51,7 @@ public:
   ~TcpSocketHandler();
 
   void close();
-  void connect();
+  void connect(const uint32_t);
   void disConnect();
   bool isConnected() const;
   void send(const void *, uint32_t);

--- a/mg400_interface/include/mg400_interface/tcp_interface/tcp_socket_handler.hpp
+++ b/mg400_interface/include/mg400_interface/tcp_interface/tcp_socket_handler.hpp
@@ -51,11 +51,11 @@ public:
   ~TcpSocketHandler();
 
   void close();
-  void connect(const uint32_t);
+  void connect(const std::chrono::nanoseconds &);
   void disConnect();
   bool isConnected() const;
   void send(const void *, uint32_t);
-  bool recv(void *, uint32_t, uint32_t);
+  bool recv(void *, uint32_t, const std::chrono::nanoseconds &);
   std::string toString();
 };
 }  // namespace mg400_interface

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -55,6 +55,12 @@ bool MG400Interface::activate()
   while (!is_connected()) {
     if (clock.now() - start > rclcpp::Duration(3s)) {
       RCLCPP_ERROR(this->getLogger(), "Could not connect DOBOT MG400.");
+      std::thread disconnect1([this](){ this->dashboard_tcp_if_->disConnect(); });
+      std::thread disconnect2([this](){ this->realtime_tcp_interface->disConnect(); });
+      std::thread disconnect3([this](){ this->motion_tcp_if_->disConnect(); });
+      disconnect1.join();
+      disconnect2.join();
+      disconnect3.join();
       return false;
     }
 

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -56,7 +56,7 @@ bool MG400Interface::activate()
   if (this->isConnected() && !this->ok()) {
     RCLCPP_WARN(
       this->getLogger(),
-      "Connection established but no response from DOBOT MG400. Waiting...");
+      "Connection established but no data sent from DOBOT MG400. Waiting...");
     if (rclcpp::sleep_for(10s) && !this->ok()) {
       this->deactivate();
       return false;

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -46,7 +46,7 @@ bool MG400Interface::activate()
   auto clock = rclcpp::Clock();
   const auto start = clock.now();
 
-  if (rclcpp::sleep_for(1s) && !this->ok()) {
+  if (rclcpp::sleep_for(2s) && !this->ok()) {
     RCLCPP_ERROR(this->getLogger(), "Could not connect DOBOT MG400.");
     // disconnect each interface in parallel because it takes time sometimes.
     std::thread discnt_dashboard_tcp_if_([this](){ this->dashboard_tcp_if_->disConnect(); });

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -53,7 +53,9 @@ bool MG400Interface::activate()
   }
 
   if (this->isConnected() && !this->ok()) {
-    RCLCPP_WARN(this->getLogger(), "Connection established but no response from DOBOT MG400. Waiting...");
+    RCLCPP_WARN(
+      this->getLogger(),
+      "Connection established but no response from DOBOT MG400. Waiting...");
     if (rclcpp::sleep_for(10s) && !this->ok()) {
       this->deactivate();
       return false;
@@ -73,9 +75,9 @@ bool MG400Interface::deactivate()
   this->motion_commander.reset();
 
   // disconnect each interface in parallel because it takes time sometimes.
-  std::thread discnt_dashboard_tcp_if_([this](){ this->dashboard_tcp_if_->disConnect(); });
-  std::thread discnt_realtime_tcp_if_([this](){ this->realtime_tcp_interface->disConnect(); });
-  std::thread discnt_motion_tcp_if_([this](){ this->motion_tcp_if_->disConnect(); });
+  std::thread discnt_dashboard_tcp_if_([this]() {this->dashboard_tcp_if_->disConnect();});
+  std::thread discnt_realtime_tcp_if_([this]() {this->realtime_tcp_interface->disConnect();});
+  std::thread discnt_motion_tcp_if_([this]() {this->motion_tcp_if_->disConnect();});
   discnt_dashboard_tcp_if_.join();
   discnt_realtime_tcp_if_.join();
   discnt_motion_tcp_if_.join();

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -55,12 +55,12 @@ bool MG400Interface::activate()
   while (!is_connected()) {
     if (clock.now() - start > rclcpp::Duration(3s)) {
       RCLCPP_ERROR(this->getLogger(), "Could not connect DOBOT MG400.");
-      std::thread disconnect1([this](){ this->dashboard_tcp_if_->disConnect(); });
-      std::thread disconnect2([this](){ this->realtime_tcp_interface->disConnect(); });
-      std::thread disconnect3([this](){ this->motion_tcp_if_->disConnect(); });
-      disconnect1.join();
-      disconnect2.join();
-      disconnect3.join();
+      std::thread discnt_dashboard_tcp_if_([this](){ this->dashboard_tcp_if_->disConnect(); });
+      std::thread discnt_realtime_tcp_if_([this](){ this->realtime_tcp_interface->disConnect(); });
+      std::thread discnt_motion_tcp_if_([this](){ this->motion_tcp_if_->disConnect(); });
+      discnt_dashboard_tcp_if_.join();
+      discnt_realtime_tcp_if_.join();
+      discnt_motion_tcp_if_.join();
       return false;
     }
 

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -46,6 +46,7 @@ bool MG400Interface::activate()
   auto clock = rclcpp::Clock();
   const auto start = clock.now();
 
+  using namespace std::chrono_literals;  // NOLINT
   if (rclcpp::sleep_for(2s) && !this->isConnected()) {
     RCLCPP_ERROR(this->getLogger(), "Could not connect to DOBOT MG400.");
     this->deactivate();

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -46,27 +46,17 @@ void DashboardTcpInterface::init() noexcept
 
 void DashboardTcpInterface::checkConnection()
 {
-  while (true) {
-    if (!this->is_running_.load()) {
-      return;
-    }
+  while (this->is_running_.load()) {
     try {
-      if (this->tcp_socket_->isConnected()) {
+      if (!this->tcp_socket_->isConnected()) {
+        this->tcp_socket_->connect(1s);
+      } else {
         rclcpp::sleep_for(1s);
         continue;
-      } else {
-        try {
-          this->tcp_socket_->connect(1s);
-        } catch (const TcpSocketException & err) {
-          RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
-          this->is_running_.store(false);
-          return;
-        }
       }
     } catch (const TcpSocketException & err) {
       this->tcp_socket_->disConnect();
       RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
-      this->is_running_.store(false);
       return;
     }
   }

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -58,7 +58,7 @@ void DashboardTcpInterface::checkConnection()
         continue;
       } else {
         try {
-          this->tcp_socket_->connect();
+          this->tcp_socket_->connect(1000);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
           rclcpp::sleep_for(500ms);

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -16,6 +16,8 @@
 
 namespace mg400_interface
 {
+using namespace std::chrono_literals; // NOLINT
+
 DashboardTcpInterface::DashboardTcpInterface(const std::string & ip)
 {
   this->is_running_.store(false);
@@ -44,7 +46,6 @@ void DashboardTcpInterface::init() noexcept
 
 void DashboardTcpInterface::checkConnection()
 {
-  using namespace std::chrono_literals;
   while (true) {
     if (!this->is_running_.load()) {
       return;
@@ -55,7 +56,7 @@ void DashboardTcpInterface::checkConnection()
         continue;
       } else {
         try {
-          this->tcp_socket_->connect(1000);
+          this->tcp_socket_->connect(1s);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
           this->is_running_.store(false);
@@ -94,7 +95,7 @@ void DashboardTcpInterface::disConnect()
 std::string DashboardTcpInterface::recvResponse()
 {
   char buf[100];
-  this->tcp_socket_->recv(buf, sizeof(buf), 500);
+  this->tcp_socket_->recv(buf, sizeof(buf), 500ms);
   RCLCPP_DEBUG(this->getLogger(), "recv: %s", std::string(buf).c_str());
   return std::string(buf);
 }

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -44,16 +44,13 @@ void DashboardTcpInterface::init() noexcept
 
 void DashboardTcpInterface::checkConnection()
 {
-  static const int CONNECTION_TRIAL = 3;
   using namespace std::chrono_literals;
-  int failed_cnt = 0;
-  while (failed_cnt < CONNECTION_TRIAL) {
+  while (true) {
     if (!this->is_running_.load()) {
       return;
     }
     try {
       if (this->tcp_socket_->isConnected()) {
-        failed_cnt = 0;
         rclcpp::sleep_for(1s);
         continue;
       } else {
@@ -61,20 +58,17 @@ void DashboardTcpInterface::checkConnection()
           this->tcp_socket_->connect(1000);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
-          rclcpp::sleep_for(500ms);
-          failed_cnt++;
+          this->is_running_.store(false);
+          return;
         }
       }
     } catch (const TcpSocketException & err) {
       this->tcp_socket_->disConnect();
       RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
-      rclcpp::sleep_for(500ms);
-      failed_cnt++;
+      this->is_running_.store(false);
+      return;
     }
   }
-
-  RCLCPP_ERROR(this->getLogger(), "Failed more than %d times... Close connection.", failed_cnt);
-  this->is_running_.store(false);
 }
 
 bool DashboardTcpInterface::isConnected()

--- a/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
@@ -59,7 +59,7 @@ void MotionTcpInterface::checkConnection()
         continue;
       } else {
         try {
-          this->tcp_socket_->connect();
+          this->tcp_socket_->connect(1000);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
           rclcpp::sleep_for(500ms);

--- a/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
@@ -45,7 +45,7 @@ void MotionTcpInterface::init() noexcept
 
 void MotionTcpInterface::checkConnection()
 {
-  using namespace std::chrono_literals;
+  using namespace std::chrono_literals; // NOLINT
   while (true) {
     if (!this->is_running_.load()) {
       return;
@@ -56,7 +56,7 @@ void MotionTcpInterface::checkConnection()
         continue;
       } else {
         try {
-          this->tcp_socket_->connect(1000);
+          this->tcp_socket_->connect(1s);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
           this->is_running_.store(false);

--- a/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
@@ -46,27 +46,17 @@ void MotionTcpInterface::init() noexcept
 void MotionTcpInterface::checkConnection()
 {
   using namespace std::chrono_literals; // NOLINT
-  while (true) {
-    if (!this->is_running_.load()) {
-      return;
-    }
+  while (this->is_running_.load()) {
     try {
-      if (this->tcp_socket_->isConnected()) {
+      if (!this->tcp_socket_->isConnected()) {
+        this->tcp_socket_->connect(1s);
+      } else {
         rclcpp::sleep_for(1s);
         continue;
-      } else {
-        try {
-          this->tcp_socket_->connect(1s);
-        } catch (const TcpSocketException & err) {
-          RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
-          this->is_running_.store(false);
-          return;
-        }
       }
     } catch (const TcpSocketException & err) {
       this->tcp_socket_->disConnect();
       RCLCPP_ERROR(this->getLogger(), "Tcp recv error : %s", err.what());
-      this->is_running_.store(false);
       return;
     }
   }

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -20,8 +20,9 @@ namespace mg400_interface
 RealtimeFeedbackTcpInterface::RealtimeFeedbackTcpInterface(
   const std::string & ip, const std::string & prefix)
 : frame_id_prefix(prefix),
-  current_joints_{}, rt_data_{}, is_running_(false)
+  current_joints_{}, rt_data_{}
 {
+  this->is_running_.store(false);
   this->tcp_socket_ = std::make_shared<TcpSocketHandler>(ip, this->PORT_);
 }
 
@@ -33,7 +34,7 @@ RealtimeFeedbackTcpInterface::~RealtimeFeedbackTcpInterface()
 void RealtimeFeedbackTcpInterface::init() noexcept
 {
   try {
-    this->is_running_ = true;
+    this->is_running_.store(true);
     this->thread_ = std::make_unique<std::thread>(&RealtimeFeedbackTcpInterface::recvData, this);
   } catch (const TcpSocketException & err) {
     RCLCPP_ERROR(this->getLogger(), "%s", err.what());
@@ -81,7 +82,7 @@ bool RealtimeFeedbackTcpInterface::isRobotMode(const uint64_t & expected_mode) c
 
 void RealtimeFeedbackTcpInterface::disConnect()
 {
-  this->is_running_ = false;
+  this->is_running_.store(false);
   if (this->thread_->joinable()) {
     this->thread_->join();
   }
@@ -95,7 +96,7 @@ void RealtimeFeedbackTcpInterface::recvData()
   using namespace std::chrono_literals;  // NOLINT
   int failed_cnd = 0;
   while (failed_cnd < CONNECTION_TRIAL) {
-    if (!this->is_running_) {
+    if (!this->is_running_.load()) {
       return;
     }
     try {
@@ -133,7 +134,7 @@ void RealtimeFeedbackTcpInterface::recvData()
   }
 
   RCLCPP_ERROR(this->getLogger(), "Failed more than %d times.. . Close connection.", failed_cnd);
-  this->is_running_ = false;
+  this->is_running_.store(false);
 }
 
 }  // namespace mg400_interface

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -112,6 +112,7 @@ void RealtimeFeedbackTcpInterface::recvData()
         auto recvd_data = std::make_shared<RealTimeData>();
         if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 5000)) {
           if (recvd_data->len != 1440) {
+            this->rt_data_ = nullptr;
             continue;
           }
           this->rt_data_ = recvd_data;

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -122,7 +122,7 @@ void RealtimeFeedbackTcpInterface::recvData()
     try {
       if (this->tcp_socket_->isConnected()) {
         auto recvd_data = std::make_shared<RealTimeData>();
-        if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 500)) {
+        if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 1000)) {
           if (recvd_data->len != 1440) {
             this->mutex_rt_data_.lock();
             this->rt_data_ = nullptr;

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -112,10 +112,8 @@ void RealtimeFeedbackTcpInterface::disConnect()
 
 void RealtimeFeedbackTcpInterface::recvData()
 {
-  static const int CONNECTION_TRIAL = 3;
   using namespace std::chrono_literals;  // NOLINT
-  int failed_cnd = 0;
-  while (failed_cnd < CONNECTION_TRIAL) {
+  while (true) {
     if (!this->is_running_.load()) {
       return;
     }
@@ -151,20 +149,16 @@ void RealtimeFeedbackTcpInterface::recvData()
           this->tcp_socket_->connect(1000);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error: %s", err.what());
-          rclcpp::sleep_for(500ms);
-          failed_cnd++;
+          this->is_running_.store(false);
+          return;
         }
       }
     } catch (const TcpSocketException & err) {
       this->tcp_socket_->disConnect();
       RCLCPP_ERROR(this->getLogger(), "Tcp recv error: %s", err.what());
-      rclcpp::sleep_for(500ms);
-      failed_cnd++;
+      this->is_running_.store(false);
     }
   }
-
-  RCLCPP_ERROR(this->getLogger(), "Failed more than %d times.. . Close connection.", failed_cnd);
-  this->is_running_.store(false);
 }
 
 }  // namespace mg400_interface

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -117,7 +117,7 @@ void RealtimeFeedbackTcpInterface::recvData()
     try {
       if (this->tcp_socket_->isConnected()) {
         auto recvd_data = std::make_shared<RealTimeData>();
-        if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 5000)) {
+        if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 500)) {
           if (recvd_data->len != 1440) {
             this->mutex_rt_data_.lock();
             this->rt_data_ = nullptr;
@@ -140,7 +140,7 @@ void RealtimeFeedbackTcpInterface::recvData()
         }
       } else {
         try {
-          this->tcp_socket_->connect();
+          this->tcp_socket_->connect(1000);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error: %s", err.what());
           rclcpp::sleep_for(500ms);

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -120,7 +120,7 @@ void RealtimeFeedbackTcpInterface::recvData()
     try {
       if (this->tcp_socket_->isConnected()) {
         auto recvd_data = std::make_shared<RealTimeData>();
-        if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 1000)) {
+        if (this->tcp_socket_->recv(recvd_data.get(), sizeof(RealTimeData), 1s)) {
           if (recvd_data->len != 1440) {
             this->mutex_rt_data_.lock();
             this->rt_data_ = nullptr;
@@ -146,7 +146,7 @@ void RealtimeFeedbackTcpInterface::recvData()
         }
       } else {
         try {
-          this->tcp_socket_->connect(1000);
+          this->tcp_socket_->connect(1s);
         } catch (const TcpSocketException & err) {
           RCLCPP_ERROR(this->getLogger(), "Tcp recv error: %s", err.what());
           this->is_running_.store(false);

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -51,6 +51,11 @@ bool RealtimeFeedbackTcpInterface::isConnected()
   return this->tcp_socket_->isConnected();
 }
 
+bool RealtimeFeedbackTcpInterface::isActive()
+{
+  return this->getRealtimeData() != nullptr;
+}
+
 void RealtimeFeedbackTcpInterface::getCurrentJointStates(std::array<double, 4> & joints)
 {
   this->mutex_current_joints_.lock();

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -142,6 +142,9 @@ void RealtimeFeedbackTcpInterface::recvData()
         } else {
           // timeout
           RCLCPP_WARN(this->getLogger(), "Tcp recv timeout");
+          this->mutex_rt_data_.lock();
+          this->rt_data_ = nullptr;
+          this->mutex_rt_data_.unlock();
         }
       } else {
         try {

--- a/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
+++ b/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
@@ -53,9 +53,11 @@ void TcpSocketHandler::connect(const std::chrono::nanoseconds & timeout)
     }
 
     timeval tv = {0, 0};
-    tv.tv_sec = timeout.count() / (int)1e9;
-    tv.tv_usec = (timeout.count() % (int)1e9) / (int)1e3;
-    if (::setsockopt(this->fd_, SOL_SOCKET, SO_SNDTIMEO, (char *)&tv, sizeof(tv)) < 0) {
+    tv.tv_sec = timeout.count() / static_cast<int>(1e9);
+    tv.tv_usec = (timeout.count() % static_cast<int>(1e9)) / static_cast<int>(1e3);
+    if (::setsockopt(
+        this->fd_, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<char *>(&tv), sizeof(tv)) < 0)
+    {
       ::close(this->fd_);
       this->fd_ = -1;
       throw TcpSocketException(this->toString() + std::string(" socket : ") + strerror(errno));
@@ -128,8 +130,8 @@ bool TcpSocketHandler::recv(void * buf, uint32_t len, const std::chrono::nanosec
     FD_ZERO(&read_fds);
     FD_SET(this->fd_, &read_fds);
 
-    tv.tv_sec = timeout.count() / (int)1e9;
-    tv.tv_usec = (timeout.count() % (int)1e9) / (int)1e3;
+    tv.tv_sec = timeout.count() / static_cast<int>(1e9);
+    tv.tv_usec = (timeout.count() % static_cast<int>(1e9)) / static_cast<int>(1e3);
     int err = ::select(this->fd_ + 1, &read_fds, nullptr, nullptr, &tv);
     if (err < 0) {
       this->disConnect();

--- a/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
+++ b/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
@@ -44,7 +44,7 @@ void TcpSocketHandler::close()
   this->fd_ = -1;
 }
 
-void TcpSocketHandler::connect(const uint32_t timeout)
+void TcpSocketHandler::connect(const std::chrono::nanoseconds & timeout)
 {
   if (this->fd_ < 0) {
     this->fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
@@ -53,8 +53,8 @@ void TcpSocketHandler::connect(const uint32_t timeout)
     }
 
     timeval tv = {0, 0};
-    tv.tv_sec = timeout / 1000;
-    tv.tv_usec = (timeout % 1000) * 1000;
+    tv.tv_sec = timeout.count() / (int)1e9;
+    tv.tv_usec = (timeout.count() % (int)1e9) / (int)1e3;
     if (::setsockopt(this->fd_, SOL_SOCKET, SO_SNDTIMEO, (char *)&tv, sizeof(tv)) < 0) {
       ::close(this->fd_);
       this->fd_ = -1;
@@ -118,7 +118,7 @@ void TcpSocketHandler::send(const void * buf, uint32_t len)
   }
 }
 
-bool TcpSocketHandler::recv(void * buf, uint32_t len, uint32_t timeout)
+bool TcpSocketHandler::recv(void * buf, uint32_t len, const std::chrono::nanoseconds & timeout)
 {
   uint8_t * tmp = reinterpret_cast<uint8_t *>(buf);
   fd_set read_fds;
@@ -128,8 +128,8 @@ bool TcpSocketHandler::recv(void * buf, uint32_t len, uint32_t timeout)
     FD_ZERO(&read_fds);
     FD_SET(this->fd_, &read_fds);
 
-    tv.tv_sec = timeout / 1000;
-    tv.tv_usec = (timeout % 1000) * 1000;
+    tv.tv_sec = timeout.count() / (int)1e9;
+    tv.tv_usec = (timeout.count() % (int)1e9) / (int)1e3;
     int err = ::select(this->fd_ + 1, &read_fds, nullptr, nullptr, &tv);
     if (err < 0) {
       this->disConnect();

--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -57,6 +57,7 @@ private:
   rclcpp::TimerBase::SharedPtr joint_state_timer_;
   rclcpp::TimerBase::SharedPtr robot_mode_timer_;
   rclcpp::TimerBase::SharedPtr error_timer_;
+  rclcpp::TimerBase::SharedPtr interface_check_timer_;
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
   rclcpp::Publisher<mg400_msgs::msg::RobotMode>::SharedPtr robot_mode_pub_;
@@ -70,6 +71,11 @@ public:
   void onJointStateTimer();
   void onRobotModeTimer();
   void onErrorTimer();
+  void onInterfaceCheckTimer();
+
+private:
+  void runTimer();
+  void cancelTimer();
 };
 }  // namespace mg400_node
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -166,7 +166,7 @@ void MG400Node::onInterfaceCheckTimer()
     this->interface_->deactivate();
     while (!this->interface_->activate()) {
       RCLCPP_INFO(this->get_logger(), "Try reconnecting...");
-      rclcpp::sleep_for(2s);
+      rclcpp::sleep_for(5s);
     }
     this->runTimer();
   }

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -46,7 +46,7 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
 
   while (!this->interface_->activate()) {
     RCLCPP_INFO(this->get_logger(), "Try reconnecting...");
-    rclcpp::sleep_for(2s);
+    rclcpp::sleep_for(5s);
   }
 
   this->dashboard_api_loader_ =

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -22,8 +22,6 @@ using namespace std::chrono_literals;   // NOLINT
 MG400Node::MG400Node(const rclcpp::NodeOptions & options)
 : rclcpp::Node("mg400_node", options)
 {
-  using namespace std::chrono_literals;  // NOLINT
-
   const std::string ip_address =
     this->declare_parameter<std::string>("ip_address", "192.168.1.6");
   RCLCPP_INFO(

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -116,9 +116,11 @@ void MG400Node::onJointStateTimer()
 void MG400Node::onRobotModeTimer()
 {
   auto msg = std::make_unique<mg400_msgs::msg::RobotMode>();
-  msg->robot_mode =
-    this->interface_->realtime_tcp_interface->getRobotMode();
-  this->robot_mode_pub_->publish(std::move(msg));
+  uint64_t mode;
+  if (this->interface_->realtime_tcp_interface->getRobotMode(mode)) {
+    msg->robot_mode = mode;
+    this->robot_mode_pub_->publish(std::move(msg));
+  }
 }
 
 void MG400Node::onErrorTimer()

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -93,7 +93,7 @@ void MG400Node::onInit()
   this->robot_mode_pub_ =
     this->create_publisher<mg400_msgs::msg::RobotMode>(
     "robot_mode", rclcpp::SensorDataQoS());
-  
+
   this->runTimer();
 }
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -160,8 +160,7 @@ void MG400Node::onErrorTimer()
 
 void MG400Node::onInterfaceCheckTimer()
 {
-  if (!this->interface_->ok())
-  {
+  if (!this->interface_->ok()) {
     // Stop the timer and try to reconnect
     this->cancelTimer();
     this->interface_->deactivate();

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -20,6 +20,7 @@ namespace mg400_node
 MG400Node::MG400Node(const rclcpp::NodeOptions & options)
 : rclcpp::Node("mg400_node", options)
 {
+  using namespace std::chrono_literals;  // NOLINT
 
   const std::string ip_address =
     this->declare_parameter<std::string>("ip_address", "192.168.1.6");
@@ -41,9 +42,9 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
     return;
   }
 
-  if (!this->interface_->activate()) {
-    exit(EXIT_FAILURE);
-    return;
+  while (!this->interface_->activate()) {
+    RCLCPP_INFO(this->get_logger(), "Try reconnecting...");
+    rclcpp::sleep_for(2s);
   }
 
   this->dashboard_api_loader_ =
@@ -56,8 +57,6 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
   this->motion_api_loader_->loadPlugins(
     this->get_parameter("motion_api_plugins").as_string_array());
 
-
-  using namespace std::chrono_literals;   // NOLINT
   this->init_timer_ = this->create_wall_timer(
     0s, std::bind(&MG400Node::onInit, this));
 }
@@ -104,56 +103,62 @@ void MG400Node::onInit()
 
 void MG400Node::onJointStateTimer()
 {
-  static std::array<double, 4> joint_states;
-  this->interface_->realtime_tcp_interface->getCurrentJointStates(joint_states);
+  if (this->interface_->ok()) {
+    static std::array<double, 4> joint_states;
+    this->interface_->realtime_tcp_interface->getCurrentJointStates(joint_states);
 
-  this->joint_state_pub_->publish(
-    mg400_interface::JointHandler::getJointState(
-      joint_states,
-      this->interface_->realtime_tcp_interface->frame_id_prefix));
+    this->joint_state_pub_->publish(
+      mg400_interface::JointHandler::getJointState(
+        joint_states,
+        this->interface_->realtime_tcp_interface->frame_id_prefix));
+  }
 }
 
 void MG400Node::onRobotModeTimer()
 {
-  auto msg = std::make_unique<mg400_msgs::msg::RobotMode>();
-  uint64_t mode;
-  if (this->interface_->realtime_tcp_interface->getRobotMode(mode)) {
-    msg->robot_mode = mode;
-    this->robot_mode_pub_->publish(std::move(msg));
+  if (this->interface_->ok()) {
+    auto msg = std::make_unique<mg400_msgs::msg::RobotMode>();
+    uint64_t mode;
+    if (this->interface_->realtime_tcp_interface->getRobotMode(mode)) {
+      msg->robot_mode = mode;
+      this->robot_mode_pub_->publish(std::move(msg));
+    }
   }
 }
 
 void MG400Node::onErrorTimer()
 {
-  if (!this->interface_->realtime_tcp_interface->isRobotMode(
-      mg400_msgs::msg::RobotMode::ERROR))
-  {
-    return;
-  }
-
-  try {
-    std::stringstream ss;
-    const auto joints_error_ids =
-      this->interface_->dashboard_commander->getErrorId();
-    for (size_t i = 0; i < joints_error_ids.size(); ++i) {
-      if (joints_error_ids.at(i).empty()) {
-        continue;
-      }
-      ss << "Joint" << (i + 1) << ":" << std::endl;
-      for (auto error_id : joints_error_ids.at(i)) {
-        const auto message =
-          this->interface_->error_msg_generator->get(error_id);
-        ss << "\t" << message << std::endl;
-      }
+  if (this->interface_->ok()) {
+    if (!this->interface_->realtime_tcp_interface->isRobotMode(
+        mg400_msgs::msg::RobotMode::ERROR))
+    {
+      return;
     }
-    RCLCPP_ERROR(this->get_logger(), ss.str().c_str());
-    this->interface_->dashboard_commander->clearError();
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->get_logger(), ex.what());
-  } catch (const std::out_of_range & ex) {
-    RCLCPP_ERROR(this->get_logger(), "Out of range %s", ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->get_logger(), "Unknown exception");
+
+    try {
+      std::stringstream ss;
+      const auto joints_error_ids =
+        this->interface_->dashboard_commander->getErrorId();
+      for (size_t i = 0; i < joints_error_ids.size(); ++i) {
+        if (joints_error_ids.at(i).empty()) {
+          continue;
+        }
+        ss << "Joint" << (i + 1) << ":" << std::endl;
+        for (auto error_id : joints_error_ids.at(i)) {
+          const auto message =
+            this->interface_->error_msg_generator->get(error_id);
+          ss << "\t" << message << std::endl;
+        }
+      }
+      RCLCPP_ERROR(this->get_logger(), ss.str().c_str());
+      this->interface_->dashboard_commander->clearError();
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->get_logger(), ex.what());
+    } catch (const std::out_of_range & ex) {
+      RCLCPP_ERROR(this->get_logger(), "Out of range %s", ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->get_logger(), "Unknown exception");
+    }
   }
 }
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -192,6 +192,4 @@ void MG400Node::cancelTimer()
   this->error_timer_.reset();
 }
 
-
-
 }  // namespace mg400_node


### PR DESCRIPTION
This pull request updates mg400 interface and mg400 node to keep running mg400 node even when mg400 is not present or disconnected.

To do this, the following features are updated

- new method `MG400Interface::ok()` was introduced
  - which returns `true` when mg400_interface's connections are established and mg400 sends realtime data back. If the connection gets broken or mg400 doesn't send realtime data, this method returns `false`.
  - This method is used by mg400_node to check if the connection is established, and mg400_plugins to check when handling their service call or action call.
- mg400_node tries to connect to mg400 when mg400_interface's `activate()` fails or mg400_interface's `ok()` returns false
  - In the previous implementation, it exited as soon as the interface is broken or not established. This pull request doesn't exit
- mg400_interface returns false when `activate()` as soon as it fails
  - mg400_interface will not retry connecting mg400. Instead, mg400_node (or some other nodes that handles mg400_interface) is responsible for the retry.