### PR TITLE
Check mg400 interface connection when handling service and action call in mg400 plugins

### DIFF
--- a/mg400_interface/include/mg400_interface/mg400_interface.hpp
+++ b/mg400_interface/include/mg400_interface/mg400_interface.hpp
@@ -36,6 +36,7 @@ class MG400Interface
 {
 public:
   using UniquePtr = std::unique_ptr<MG400Interface>;
+  using SharedPtr = std::shared_ptr<MG400Interface>;
 
   DashboardCommander::SharedPtr dashboard_commander;
   MotionCommander::SharedPtr motion_commander;

--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -45,7 +45,7 @@ private:
     "mg400_plugin::MovJ",
     "mg400_plugin::MovL"
   };
-  mg400_interface::MG400Interface::UniquePtr interface_;
+  mg400_interface::MG400Interface::SharedPtr interface_;
 
   mg400_plugin_base::DashboardApiLoader::SharedPtr
     dashboard_api_loader_;

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -34,7 +34,7 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
 
 
   this->interface_ =
-    std::make_unique<mg400_interface::MG400Interface>(ip_address);
+    std::make_shared<mg400_interface::MG400Interface>(ip_address);
 
   this->declare_parameter<std::string>("prefix", "");
   if (!this->interface_->configure(this->get_parameter("prefix").as_string())) {
@@ -74,14 +74,15 @@ void MG400Node::onInit()
 
   this->dashboard_api_loader_->configure(
     this->interface_->dashboard_commander,
-    this->shared_from_this());
+    this->shared_from_this(),
+    this->interface_);
   this->dashboard_api_loader_->showPluginInfo(
     this->get_node_logging_interface());
 
   this->motion_api_loader_->configure(
     this->interface_->motion_commander,
     this->shared_from_this(),
-    this->interface_->realtime_tcp_interface);
+    this->interface_);
   this->motion_api_loader_->showPluginInfo(
     this->get_node_logging_interface());
 

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/acc_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/acc_j.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/acc_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/acc_l.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/arch.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/arch.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/clear_error.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/clear_error.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/cp.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/cp.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/di.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/di.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/disable_robot.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/disable_robot.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/do.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/do.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/emergency_stop.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/emergency_stop.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/enable_robot.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/enable_robot.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/get_angle.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/get_angle.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/get_pose.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/get_pose.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/pay_load.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/pay_load.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/reset_robot.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/reset_robot.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/robot_mode.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/robot_mode.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/set_collision_level.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/set_collision_level.hpp
@@ -31,7 +31,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_factor.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_factor.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_j.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_l.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/tool.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/tool.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/tool_do_execute.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/tool_do_execute.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/user.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/user.hpp
@@ -32,7 +32,7 @@ public:
   void configure(
     const mg400_interface::DashboardCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
@@ -37,7 +37,7 @@ public:
   void configure(
     const mg400_interface::MotionCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr)
+    const mg400_interface::MG400Interface::SharedPtr)
   override;
 
 private:

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_l.hpp
@@ -37,7 +37,7 @@ public:
   void configure(
     const mg400_interface::MotionCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr)
+    const mg400_interface::MG400Interface::SharedPtr)
   override;
 
 private:

--- a/mg400_plugin/include/mg400_plugin/motion_api/move_jog.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/move_jog.hpp
@@ -33,7 +33,7 @@ public:
   void configure(
     const mg400_interface::MotionCommander::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) override;
+    const mg400_interface::MG400Interface::SharedPtr) override;
 
 private:
   void onServiceCall(

--- a/mg400_plugin/package.xml
+++ b/mg400_plugin/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>mg400_interface</depend>
   <depend>mg400_msgs</depend>
   <depend>mg400_plugin_base</depend>
   <depend>rclcpp_action</depend>

--- a/mg400_plugin/src/dashboard_api/acc_j.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_j.cpp
@@ -21,9 +21,9 @@ namespace mg400_plugin
 void AccJ::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/acc_j.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_j.cpp
@@ -38,13 +38,17 @@ void AccJ::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->accJ(static_cast<int>(req->r));
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->accJ(static_cast<int>(req->r));
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/acc_l.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_l.cpp
@@ -21,9 +21,9 @@ namespace mg400_plugin
 void AccL::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/acc_l.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_l.cpp
@@ -38,13 +38,17 @@ void AccL::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->accL(static_cast<int>(req->r));
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->accL(static_cast<int>(req->r));
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/arch.cpp
+++ b/mg400_plugin/src/dashboard_api/arch.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void Arch::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/arch.cpp
+++ b/mg400_plugin/src/dashboard_api/arch.cpp
@@ -37,13 +37,17 @@ void Arch::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->arch(req->index);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->arch(req->index);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/clear_error.cpp
+++ b/mg400_plugin/src/dashboard_api/clear_error.cpp
@@ -38,13 +38,17 @@ void ClearError::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->clearError();
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->clearError();
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/clear_error.cpp
+++ b/mg400_plugin/src/dashboard_api/clear_error.cpp
@@ -21,9 +21,9 @@ namespace mg400_plugin
 void ClearError::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -37,13 +37,17 @@ void CP::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->cp(req->r);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->cp(req->r);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void CP::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/di.cpp
+++ b/mg400_plugin/src/dashboard_api/di.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void DI::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/di.cpp
+++ b/mg400_plugin/src/dashboard_api/di.cpp
@@ -36,12 +36,16 @@ void DI::onServiceCall(
   const ServiceT::Request::SharedPtr req,
   ServiceT::Response::SharedPtr res)
 {
-  try {
-    res->result = this->commander_->DI(req->index.index);
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      res->result = this->commander_->DI(req->index.index);
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/disable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/disable_robot.cpp
@@ -36,13 +36,17 @@ void DisableRobot::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->disableRobot();
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->disableRobot();
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/disable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/disable_robot.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void DisableRobot::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/do.cpp
+++ b/mg400_plugin/src/dashboard_api/do.cpp
@@ -37,13 +37,17 @@ void DO::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->DO(req->index, req->status);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->DO(req->index, req->status);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/do.cpp
+++ b/mg400_plugin/src/dashboard_api/do.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void DO::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/emergency_stop.cpp
+++ b/mg400_plugin/src/dashboard_api/emergency_stop.cpp
@@ -38,13 +38,17 @@ void EmergencyStop::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->emergencyStop();
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->emergencyStop();
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/emergency_stop.cpp
+++ b/mg400_plugin/src/dashboard_api/emergency_stop.cpp
@@ -21,9 +21,9 @@ namespace mg400_plugin
 void EmergencyStop::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/enable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/enable_robot.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void EnableRobot::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/enable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/enable_robot.cpp
@@ -36,13 +36,17 @@ void EnableRobot::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->enableRobot();
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->enableRobot();
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/get_angle.cpp
+++ b/mg400_plugin/src/dashboard_api/get_angle.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void GetAngle::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/get_angle.cpp
+++ b/mg400_plugin/src/dashboard_api/get_angle.cpp
@@ -36,18 +36,22 @@ void GetAngle::onServiceCall(
   const ServiceT::Request::SharedPtr,
   ServiceT::Response::SharedPtr res)
 {
-  try {
-    auto joints = this->commander_->getAngle();
-    res->joint1 = joints[0];
-    res->joint2 = joints[1];
-    res->joint3 = joints[2];
-    res->joint4 = joints[3];
-    res->joint5 = joints[4];
-    res->joint6 = joints[5];
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      auto joints = this->commander_->getAngle();
+      res->joint1 = joints[0];
+      res->joint2 = joints[1];
+      res->joint3 = joints[2];
+      res->joint4 = joints[3];
+      res->joint5 = joints[4];
+      res->joint6 = joints[5];
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/get_pose.cpp
+++ b/mg400_plugin/src/dashboard_api/get_pose.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void GetPose::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/get_pose.cpp
+++ b/mg400_plugin/src/dashboard_api/get_pose.cpp
@@ -36,18 +36,22 @@ void GetPose::onServiceCall(
   const ServiceT::Request::SharedPtr,
   ServiceT::Response::SharedPtr res)
 {
-  try {
-    auto poses = this->commander_->getPose();
-    res->pose1 = poses[0];
-    res->pose2 = poses[1];
-    res->pose3 = poses[2];
-    res->pose4 = poses[3];
-    res->pose5 = poses[4];
-    res->pose6 = poses[5];
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      auto poses = this->commander_->getPose();
+      res->pose1 = poses[0];
+      res->pose2 = poses[1];
+      res->pose3 = poses[2];
+      res->pose4 = poses[3];
+      res->pose5 = poses[4];
+      res->pose6 = poses[5];
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/pay_load.cpp
+++ b/mg400_plugin/src/dashboard_api/pay_load.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void PayLoad::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/pay_load.cpp
+++ b/mg400_plugin/src/dashboard_api/pay_load.cpp
@@ -37,13 +37,17 @@ void PayLoad::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->payload(req->weight, req->inertia);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->payload(req->weight, req->inertia);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/reset_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/reset_robot.cpp
@@ -36,13 +36,17 @@ void ResetRobot::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->resetRobot();
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->resetRobot();
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/reset_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/reset_robot.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void ResetRobot::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/robot_mode.cpp
+++ b/mg400_plugin/src/dashboard_api/robot_mode.cpp
@@ -36,12 +36,16 @@ void RobotMode::onServiceCall(
   const ServiceT::Request::SharedPtr,
   ServiceT::Response::SharedPtr res)
 {
-  try {
-    res->robot_mode.robot_mode = this->commander_->robotMode();
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      res->robot_mode.robot_mode = this->commander_->robotMode();
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/robot_mode.cpp
+++ b/mg400_plugin/src/dashboard_api/robot_mode.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void RobotMode::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/set_collision_level.cpp
+++ b/mg400_plugin/src/dashboard_api/set_collision_level.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void SetCollisionLevel::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/set_collision_level.cpp
+++ b/mg400_plugin/src/dashboard_api/set_collision_level.cpp
@@ -37,13 +37,17 @@ void SetCollisionLevel::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->setCollisionLevel(req->level);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->setCollisionLevel(req->level);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/speed_factor.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_factor.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void SpeedFactor::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/speed_factor.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_factor.cpp
@@ -36,13 +36,17 @@ void SpeedFactor::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->speedFactor(static_cast<int>(req->ratio));
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->speedFactor(static_cast<int>(req->ratio));
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/speed_j.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_j.cpp
@@ -38,13 +38,17 @@ void SpeedJ::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->speedJ(static_cast<int>(req->r));
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->speedJ(static_cast<int>(req->r));
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/speed_j.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_j.cpp
@@ -21,9 +21,9 @@ namespace mg400_plugin
 void SpeedJ::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/speed_l.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_l.cpp
@@ -38,13 +38,17 @@ void SpeedL::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->speedL(static_cast<int>(req->r));
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->speedL(static_cast<int>(req->r));
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/speed_l.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_l.cpp
@@ -21,9 +21,9 @@ namespace mg400_plugin
 void SpeedL::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/tool.cpp
+++ b/mg400_plugin/src/dashboard_api/tool.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void Tool::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/tool.cpp
+++ b/mg400_plugin/src/dashboard_api/tool.cpp
@@ -36,13 +36,17 @@ void Tool::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->tool(req->tool);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->tool(req->tool);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namsespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
+++ b/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
@@ -37,14 +37,18 @@ void ToolDOExecute::onServiceCall(
 )
 {
   res->result = false;
-  try {
-    this->commander_->toolDOExecute(
-      req->index, req->status);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->toolDOExecute(
+        req->index, req->status);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
+++ b/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void ToolDOExecute::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/dashboard_api/user.cpp
+++ b/mg400_plugin/src/dashboard_api/user.cpp
@@ -36,13 +36,17 @@ void User::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
-  try {
-    this->commander_->user(req->user);
-    res->result = true;
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->user(req->user);
+      res->result = true;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namsespace mg400_plugin

--- a/mg400_plugin/src/dashboard_api/user.cpp
+++ b/mg400_plugin/src/dashboard_api/user.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void User::configure(
   const mg400_interface::DashboardCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -120,7 +120,8 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     [&](geometry_msgs::msg::PoseStamped & msg) -> void
     {
       msg.header.stamp = this->base_node_->get_clock()->now();
-      msg.header.frame_id = this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link";
+      msg.header.frame_id =
+        this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link";
       this->mg400_interface_->realtime_tcp_interface->getCurrentEndPose(msg.pose);
     };
 

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -30,7 +30,8 @@ void MovJ::configure(
   tf_handler_ = std::make_shared<h6x_tf_handler::PoseTfHandler>(
     node->get_node_clock_interface(), node->get_node_logging_interface());
   tf_handler_->configure();
-  tf_handler_->setDistFrameId(this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link");
+  tf_handler_->setDistFrameId(
+    this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link");
   tf_handler_->activate();
 
   using namespace std::placeholders;  // NOLINT

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -20,9 +20,9 @@ namespace mg400_plugin
 void MovJ::configure(
   const mg400_interface::MotionCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 
@@ -30,7 +30,7 @@ void MovJ::configure(
   tf_handler_ = std::make_shared<h6x_tf_handler::PoseTfHandler>(
     node->get_node_clock_interface(), node->get_node_logging_interface());
   tf_handler_->configure();
-  tf_handler_->setDistFrameId(this->realtime_tcp_interface_->frame_id_prefix + "mg400_origin_link");
+  tf_handler_->setDistFrameId(this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link");
   tf_handler_->activate();
 
   using namespace std::placeholders;  // NOLINT
@@ -47,7 +47,7 @@ rclcpp_action::GoalResponse MovJ::handle_goal(
   const rclcpp_action::GoalUUID &, ActionT::Goal::ConstSharedPtr)
 {
   using RobotMode = mg400_msgs::msg::RobotMode;
-  if (!this->realtime_tcp_interface_->isRobotMode(RobotMode::ENABLE)) {
+  if (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ENABLE)) {
     RCLCPP_ERROR(
       this->base_node_->get_logger(), "Robot mode is not enabled");
     return rclcpp_action::GoalResponse::REJECT;
@@ -113,8 +113,8 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     [&](geometry_msgs::msg::PoseStamped & msg) -> void
     {
       msg.header.stamp = this->base_node_->get_clock()->now();
-      msg.header.frame_id = this->realtime_tcp_interface_->frame_id_prefix + "mg400_origin_link";
-      this->realtime_tcp_interface_->getCurrentEndPose(msg.pose);
+      msg.header.frame_id = this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link";
+      this->mg400_interface_->realtime_tcp_interface->getCurrentEndPose(msg.pose);
     };
 
 
@@ -126,7 +126,7 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   update_pose(feedback->current_pose);
 
   while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
-    if (this->realtime_tcp_interface_->isRobotMode(RobotMode::ERROR)) {
+    if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
       RCLCPP_ERROR(this->base_node_->get_logger(), "Robot Mode Error");
       goal_handle->abort(result);
       return;

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -46,6 +46,12 @@ void MovL::configure(
 rclcpp_action::GoalResponse MovL::handle_goal(
   const rclcpp_action::GoalUUID &, ActionT::Goal::ConstSharedPtr)
 {
+  if (!this->mg400_interface_->ok()) {
+    RCLCPP_ERROR(
+      this->base_node_->get_logger(), "MG400 is not connected");
+    return rclcpp_action::GoalResponse::REJECT;
+  }
+
   using RobotMode = mg400_msgs::msg::RobotMode;
   if (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ENABLE)) {
     RCLCPP_ERROR(
@@ -127,6 +133,12 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   update_pose(feedback->current_pose);
 
   while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
+    if (!this->mg400_interface_->ok()) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 Connection Error");
+      goal_handle->abort(result);
+      return;
+    }
+
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
       RCLCPP_ERROR(this->base_node_->get_logger(), "Robot Mode Error");
       goal_handle->abort(result);

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -30,7 +30,8 @@ void MovL::configure(
   tf_handler_ = std::make_shared<h6x_tf_handler::PoseTfHandler>(
     node->get_node_clock_interface(), node->get_node_logging_interface());
   tf_handler_->configure();
-  tf_handler_->setDistFrameId(this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link");
+  tf_handler_->setDistFrameId(
+    this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link");
   tf_handler_->activate();
 
   using namespace std::placeholders;  // NOLINT

--- a/mg400_plugin/src/motion_api/move_jog.cpp
+++ b/mg400_plugin/src/motion_api/move_jog.cpp
@@ -19,9 +19,9 @@ namespace mg400_plugin
 void MoveJog::configure(
   const mg400_interface::MotionCommander::SharedPtr commander,
   const rclcpp::Node::SharedPtr node,
-  const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr rt_if)
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
 {
-  if (!this->configure_base(commander, node, rt_if)) {
+  if (!this->configure_base(commander, node, mg400_if)) {
     return;
   }
 

--- a/mg400_plugin/src/motion_api/move_jog.cpp
+++ b/mg400_plugin/src/motion_api/move_jog.cpp
@@ -36,12 +36,16 @@ void MoveJog::onServiceCall(
   const ServiceT::Request::SharedPtr req,
   ServiceT::Response::SharedPtr)
 {
-  try {
-    this->commander_->moveJog(req->jog.jog_mode);
-  } catch (const std::runtime_error & ex) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
-  } catch (...) {
-    RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+  if (this->mg400_interface_->ok()) {
+    try {
+      this->commander_->moveJog(req->jog.jog_mode);
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->base_node_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->base_node_->get_logger(), "MG400 is not connected");
   }
 }
 }  // namespace mg400_plugin

--- a/mg400_plugin_base/include/mg400_plugin_base/api_loader_base.hpp
+++ b/mg400_plugin_base/include/mg400_plugin_base/api_loader_base.hpp
@@ -62,12 +62,10 @@ public:
   void configure(
     typename PluginT::CommanderT::SharedPtr commander,
     const rclcpp::Node::SharedPtr node,
-    mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr
-    rt_if = nullptr
-  )
+    mg400_interface::MG400Interface::SharedPtr mg400_if)
   {
     for (const auto & it : this->plugin_map_) {
-      it.second->configure(commander, node->shared_from_this(), rt_if);
+      it.second->configure(commander, node->shared_from_this(), mg400_if);
     }
   }
 

--- a/mg400_plugin_base/include/mg400_plugin_base/api_plugin_base.hpp
+++ b/mg400_plugin_base/include/mg400_plugin_base/api_plugin_base.hpp
@@ -33,8 +33,8 @@ public:
 protected:
   typename CommanderT::SharedPtr commander_;
   rclcpp::Node::SharedPtr base_node_;
-  mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr
-    realtime_tcp_interface_;
+  mg400_interface::MG400Interface::SharedPtr
+    mg400_interface_;
 
 public:
   ApiPluginBase() {}
@@ -42,14 +42,13 @@ public:
   virtual void configure(
     const typename CommanderT::SharedPtr,
     const rclcpp::Node::SharedPtr,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr) = 0;
+    const mg400_interface::MG400Interface::SharedPtr) = 0;
 
 protected:
   bool configure_base(
     const typename CommanderT::SharedPtr commander,
     const rclcpp::Node::SharedPtr node,
-    const mg400_interface::RealtimeFeedbackTcpInterface::SharedPtr
-    rt_if = nullptr)
+    const mg400_interface::MG400Interface::SharedPtr mg400_if)
   {
     if (this->base_node_) {
       RCLCPP_WARN(
@@ -61,8 +60,8 @@ protected:
     this->commander_ = commander;
     this->base_node_ = node;
 
-    if (rt_if) {
-      this->realtime_tcp_interface_ = rt_if;
+    if (mg400_if) {
+      this->mg400_interface_ = mg400_if;
     }
 
     return true;


### PR DESCRIPTION
This pull request is based on this another pull request:

- #167 

In this pull request, mg400 plugins are updated to check the mg400 interface connection when they handle service request or action request. If the connection is broken, the service will return false and action will be aborted.