### PR TITLE
Fixed rviz panel plugin for mg400 control. 

### DIFF
--- a/mg400_rviz_plugin/src/panel_mg400_controller.cpp
+++ b/mg400_rviz_plugin/src/panel_mg400_controller.cpp
@@ -188,7 +188,9 @@ void Mg400ControllerPanel::callbackSendMovJ()
 
 void Mg400ControllerPanel::callEnableRobot()
 {
-  if (this->current_robot_mode_ == RobotMode::ENABLE) {
+  if (this->current_robot_mode_ == RobotMode::ENABLE ||
+    this->current_robot_mode_ == RobotMode::RUNNING)
+  {
     RCLCPP_WARN(nh_->get_logger(), "robot already enabled");
     return;
   }


### PR DESCRIPTION
Fix a bug on  #174
Now robot_mode RUNNING is not interrupted by Enable button on panel.