### PR TITLE
Add servo error message generator along with controller erro message generator to MG400Interface

### DIFF
--- a/mg400_interface/include/mg400_interface/mg400_interface.hpp
+++ b/mg400_interface/include/mg400_interface/mg400_interface.hpp
@@ -42,7 +42,8 @@ public:
   MotionCommander::SharedPtr motion_commander;
   RealtimeFeedbackTcpInterface::SharedPtr realtime_tcp_interface;
 
-  std::unique_ptr<ErrorMsgGenerator> error_msg_generator;
+  std::unique_ptr<ErrorMsgGenerator> controller_error_msg_generator;
+  std::unique_ptr<ErrorMsgGenerator> servo_error_msg_generator;
 
 private:
   const std::string IP;

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -35,7 +35,7 @@ bool MG400Interface::configure(const std::string & frame_id_prefix)
     std::make_unique<ErrorMsgGenerator>("alarm_servo.json");
 
   return this->controller_error_msg_generator->loadJsonFile() &&
-    this->servo_error_msg_generator->loadJsonFile();
+         this->servo_error_msg_generator->loadJsonFile();
 }
 
 

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -29,10 +29,13 @@ bool MG400Interface::configure(const std::string & frame_id_prefix)
   this->realtime_tcp_interface = std::make_shared<RealtimeFeedbackTcpInterface>(
     this->IP, frame_id_prefix);
 
-  this->error_msg_generator =
+  this->controller_error_msg_generator =
     std::make_unique<ErrorMsgGenerator>("alarm_controller.json");
+  this->servo_error_msg_generator =
+    std::make_unique<ErrorMsgGenerator>("alarm_servo.json");
 
-  return this->error_msg_generator->loadJsonFile();
+  return this->controller_error_msg_generator->loadJsonFile() &&
+    this->servo_error_msg_generator->loadJsonFile();
 }
 
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -132,16 +132,25 @@ void MG400Node::onErrorTimer()
 
     try {
       std::stringstream ss;
-      const auto joints_error_ids =
+      const auto error_ids =
         this->interface_->dashboard_commander->getErrorId();
-      for (size_t i = 0; i < joints_error_ids.size(); ++i) {
-        if (joints_error_ids.at(i).empty()) {
+      
+      if (!error_ids.at(0).empty()) {
+        ss << "Controller and Algorith:" << std::endl;
+        for (auto error_id : error_ids.at(0)) {
+          const auto message =
+            this->interface_->controller_error_msg_generator->get(error_id);
+          ss << "\t" << message << std::endl;
+        }
+      }
+      for (size_t i = 1; i < error_ids.size(); ++i) {
+        if (error_ids.at(i).empty()) {
           continue;
         }
-        ss << "Joint" << (i + 1) << ":" << std::endl;
-        for (auto error_id : joints_error_ids.at(i)) {
+        ss << "Servo" << i << ":" << std::endl;
+        for (auto error_id : error_ids.at(i)) {
           const auto message =
-            this->interface_->error_msg_generator->get(error_id);
+            this->interface_->servo_error_msg_generator->get(error_id);
           ss << "\t" << message << std::endl;
         }
       }

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -134,7 +134,6 @@ void MG400Node::onErrorTimer()
       std::stringstream ss;
       const auto error_ids =
         this->interface_->dashboard_commander->getErrorId();
-      
       if (!error_ids.at(0).empty()) {
         ss << "Controller and Algorith:" << std::endl;
         for (auto error_id : error_ids.at(0)) {


### PR DESCRIPTION
Acoording to [the official dobot TCP-IP-Protocol documentation](https://github.com/Dobot-Arm/TCP-IP-Protocol/blob/master/README-EN.md#348-geterrorid), `GetErrorID`'s response is

```
{
  [
    [id, id, id, ... id],    // alarm information of controller and algorithm
    [id]                        // alarm information of servo 1
    [id]                        // alarm information of servo 2
    [id]                        // alarm information of servo 3
    [id]                        // alarm information of servo 4
    [id]                        // alarm information of servo 5
    [id]                        // alarm information of servo 6
  ]
}
```

And the error code description files (.json) of alarm information of controller and algorithm and that of servo are different. The former one is `alarm_controller.json` and the latter is `alarm_servo.json`.

However, previous MG400Interface's error message generator loads only `alarm_controller.json`, and it tries to parse all of the alarm information with it. So when it tries to parse alarm information of servo, it fails (in such case, `std::out_of_range` exception was thrown so the las `this->interface_->dashboard_commander->clearError()` won't be invoked).

To avoid this case, this pull request implements two error message generator for `alarm_controller.json` and `alarm_servo.json`, and use them for each alarm information.