### PR TITLE
Update MovJ and MovL to check the robot mode during execution

### DIFF
--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -150,6 +150,15 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   const auto start = this->node_clock_if_->get_clock()->now();
   update_pose(feedback->current_pose);
 
+  while (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::RUNNING)) {
+    if (this->node_clock_if_->get_clock()->now() - start > timeout) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
+      goal_handle->abort(result);
+      return;
+    }
+    control_freq.sleep();
+  }
+
   while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose) ||
     !this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ENABLE))
   {

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -150,7 +150,9 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   const auto start = this->node_clock_if_->get_clock()->now();
   update_pose(feedback->current_pose);
 
-  while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
+  while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose) ||
+    !this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ENABLE))
+  {
     if (!this->mg400_interface_->ok()) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 Connection Error");
       goal_handle->abort(result);

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -150,6 +150,15 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   const auto start = this->node_clock_if_->get_clock()->now();
   update_pose(feedback->current_pose);
 
+  while (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::RUNNING)) {
+    if (this->node_clock_if_->get_clock()->now() - start > timeout) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
+      goal_handle->abort(result);
+      return;
+    }
+    control_freq.sleep();
+  }
+
   while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose) ||
     !this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ENABLE))
   {

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -150,7 +150,9 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   const auto start = this->node_clock_if_->get_clock()->now();
   update_pose(feedback->current_pose);
 
-  while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
+  while (!is_goal_reached(feedback->current_pose.pose, tf_goal.pose) ||
+    !this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ENABLE))
+  {
     if (!this->mg400_interface_->ok()) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 Connection Error");
       goal_handle->abort(result);


### PR DESCRIPTION
Previous implementation of MovJ and MovL checked the robot mode (expecting it to be ENABLE) when executing, but it didn't check the mode to becomes back to ENABLE. Hence when running multiple MovJ in a sequence, sometimes the robot mode is still RUNNING and MovJ fails.

To avoid it, this pull request checkes the robot mode during execution.