### PR TITLE
Fix build warning

### DIFF
--- a/mg400_rviz_plugin/src/panel_mg400_controller.cpp
+++ b/mg400_rviz_plugin/src/panel_mg400_controller.cpp
@@ -182,6 +182,8 @@ void Mg400ControllerPanel::tick()
           return "JOG";
         case RobotMode::INVALID:
           return "INVALID";
+        default:
+          return "INVALID";
       }
     };
 


### PR DESCRIPTION
Previous implementation had the warning of `control reaches end of non-void function`. To avoid it, this pull request added default case to the switch statement.