### PR TITLE
Fix robot mode check bug

### DIFF
--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -155,19 +155,22 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   while (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::RUNNING)) {
     if (this->node_clock_if_->get_clock()->now() - start > rclcpp::Duration(300ms)) {
       if (is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
-        RCLCPP_INFO(this->node_logging_if_->get_logger(),
-	  "Arm is already at the goal. Sometimes robot mode doesn't become RUNNING.");
+        RCLCPP_INFO(
+          this->node_logging_if_->get_logger(),
+          "Arm is already at the goal.");
         break;
       }
 
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(),
+      RCLCPP_ERROR(
+        this->node_logging_if_->get_logger(),
         "execution timeout: Robot mode did not become RUNNING.");
       goal_handle->abort(result);
       return;
     }
 
-    if(this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)){
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
+    if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
+      RCLCPP_ERROR(
+        this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
       goal_handle->abort(result);
       return;
     }
@@ -185,7 +188,8 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     }
 
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error while checking reaching goal");
+      RCLCPP_ERROR(
+        this->node_logging_if_->get_logger(), "Robot Mode Error while checking goal");
       goal_handle->abort(result);
       return;
     }

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -152,7 +152,9 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
 
   while (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::RUNNING)) {
     if (this->node_clock_if_->get_clock()->now() - start > timeout) {
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
+      RCLCPP_ERROR(
+	this->node_logging_if_->get_logger(),
+	"execution timeout: Robot mode did not become RUNNING");
       goal_handle->abort(result);
       return;
     }

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -153,19 +153,22 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   while (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::RUNNING)) {
     if (this->node_clock_if_->get_clock()->now() - start > rclcpp::Duration(300ms)) {
       if (is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
-        RCLCPP_INFO(this->node_logging_if_->get_logger(),
-	  "Arm is already at the goal. Sometimes robot mode doesn't become RUNNING.");
+        RCLCPP_INFO(
+          this->node_logging_if_->get_logger(),
+          "Arm is already at the goal.");
         break;
       }
 
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(),
+      RCLCPP_ERROR(
+        this->node_logging_if_->get_logger(),
         "execution timeout: Robot mode did not become RUNNING.");
       goal_handle->abort(result);
       return;
     }
 
-    if(this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)){
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
+    if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
+      RCLCPP_ERROR(
+        this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
       goal_handle->abort(result);
       return;
     }
@@ -183,7 +186,8 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     }
 
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error while checking reaching goal");
+      RCLCPP_ERROR(
+        this->node_logging_if_->get_logger(), "Robot Mode Error while checking reaching goal");
       goal_handle->abort(result);
       return;
     }

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -146,18 +146,30 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   using RobotMode = mg400_msgs::msg::RobotMode;
   using namespace std::chrono_literals;   // NOLINT
   // TODO(anyone): Should calculate timeout with expectation goal time
-  const auto timeout = rclcpp::Duration(5s);
+  const auto timeout = rclcpp::Duration(10s);
   const auto start = this->node_clock_if_->get_clock()->now();
   update_pose(feedback->current_pose);
 
   while (!this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::RUNNING)) {
-    if (this->node_clock_if_->get_clock()->now() - start > timeout) {
-      RCLCPP_ERROR(
-	this->node_logging_if_->get_logger(),
-	"execution timeout: Robot mode did not become RUNNING");
+    if (this->node_clock_if_->get_clock()->now() - start > rclcpp::Duration(300ms)) {
+      if (is_goal_reached(feedback->current_pose.pose, tf_goal.pose)) {
+        RCLCPP_INFO(this->node_logging_if_->get_logger(),
+	  "Arm is already at the goal. Sometimes robot mode doesn't become RUNNING.");
+        break;
+      }
+
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(),
+        "execution timeout: Robot mode did not become RUNNING.");
       goal_handle->abort(result);
       return;
     }
+
+    if(this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)){
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
+      goal_handle->abort(result);
+      return;
+    }
+
     control_freq.sleep();
   }
 
@@ -171,7 +183,7 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     }
 
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
-      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error");
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Robot Mode Error while checking reaching goal");
       goal_handle->abort(result);
       return;
     }


### PR DESCRIPTION
When MovJ or MovL is requested but MG400 doesn't need to move its arm because it is already at the goal, then the robot mode won't be `RUNNING`. But in such case, current MG400_ROS2's MovJ and MovL action servers don't notice it and try to wait for it to be `RUNNING` (and then it will timed-out).

This pull request fixes this issue.