### PR TITLE
Remove unused exec depend from package.xml

### DIFF
--- a/mg400_bringup/package.xml
+++ b/mg400_bringup/package.xml
@@ -7,7 +7,6 @@
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>
 
-  <exec_depend>h6x_bringup_common</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>mg400_description</exec_depend>
   <exec_depend>mg400_joy</exec_depend>


### PR DESCRIPTION
`h6x_bringup_common` is not used in this repository, so this PR removes it.