### PR TITLE
Avoid segmentation fault when reconnecting to MG400 (which occurs only in debian package)

### DIFF
--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -75,9 +75,6 @@ bool MG400Interface::activate()
 
 bool MG400Interface::deactivate()
 {
-  this->dashboard_commander.reset();
-  this->motion_commander.reset();
-
   // disconnect each interface in parallel because it takes time sometimes.
   std::thread discnt_dashboard_tcp_if_([this]() {this->dashboard_tcp_if_->disConnect();});
   std::thread discnt_realtime_tcp_if_([this]() {this->realtime_tcp_interface->disConnect();});

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -34,6 +34,9 @@ bool MG400Interface::configure(const std::string & frame_id_prefix)
   this->servo_error_msg_generator =
     std::make_unique<ErrorMsgGenerator>("alarm_servo.json");
 
+  this->dashboard_commander = std::make_shared<DashboardCommander>(this->dashboard_tcp_if_.get());
+  this->motion_commander = std::make_shared<MotionCommander>(this->motion_tcp_if_.get());
+
   return this->controller_error_msg_generator->loadJsonFile() &&
          this->servo_error_msg_generator->loadJsonFile();
 }
@@ -65,9 +68,6 @@ bool MG400Interface::activate()
       return false;
     }
   }
-
-  this->dashboard_commander = std::make_shared<DashboardCommander>(this->dashboard_tcp_if_.get());
-  this->motion_commander = std::make_shared<MotionCommander>(this->motion_tcp_if_.get());
 
   RCLCPP_INFO(this->getLogger(), "Connected to DOBOT MG400");
   return true;

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -116,7 +116,7 @@ CallbackReturn MG400Node::on_activate(const State &)
     }
     return CallbackReturn::FAILURE;
   }
-  
+
   this->runTimer();
 
   RCLCPP_INFO(this->get_logger(), "Connected to MG400 at %s", this->ip_address_.c_str());

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -132,11 +132,6 @@ CallbackReturn MG400Node::on_deactivate(const State &)
   this->cancelTimer();
   this->interface_->deactivate();
 
-  if (this->get_parameter("auto_connect").as_bool()) {
-    RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
-    this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
-  }
-
   return CallbackReturn::SUCCESS;
 }
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -59,27 +59,6 @@ CallbackReturn MG400Node::on_configure(const State &)
     return CallbackReturn::FAILURE;
   }
 
-  if (this->get_parameter("auto_connect").as_bool()) {
-    RCLCPP_INFO(this->get_logger(), "Try connecting to MG400 at %s ...", this->ip_address_.c_str());
-    this->connect_timer_ = this->create_wall_timer(0s, [this]() {this->activate();});
-  }
-
-  return CallbackReturn::SUCCESS;
-}
-
-CallbackReturn MG400Node::on_activate(const State &)
-{
-  this->connect_timer_.reset();
-
-  if (!this->interface_->activate()) {
-    RCLCPP_WARN(this->get_logger(), "Failed to connect to MG400 at %s", this->ip_address_.c_str());
-    if (this->get_parameter("auto_connect").as_bool()) {
-      RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
-      this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
-    }
-    return CallbackReturn::FAILURE;
-  }
-
   this->dashboard_api_loader_ =
     std::make_shared<mg400_plugin_base::DashboardApiLoader>();
   this->dashboard_api_loader_->loadPlugins(
@@ -116,6 +95,28 @@ CallbackReturn MG400Node::on_activate(const State &)
     "robot_mode", rclcpp::SensorDataQoS());
   this->error_id_pub_ = this->create_publisher<mg400_msgs::msg::ErrorID>(
     "error_id", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().durability_volatile());
+
+  if (this->get_parameter("auto_connect").as_bool()) {
+    RCLCPP_INFO(this->get_logger(), "Try connecting to MG400 at %s ...", this->ip_address_.c_str());
+    this->connect_timer_ = this->create_wall_timer(0s, [this]() {this->activate();});
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn MG400Node::on_activate(const State &)
+{
+  this->connect_timer_.reset();
+
+  if (!this->interface_->activate()) {
+    RCLCPP_WARN(this->get_logger(), "Failed to connect to MG400 at %s", this->ip_address_.c_str());
+    if (this->get_parameter("auto_connect").as_bool()) {
+      RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
+      this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
+    }
+    return CallbackReturn::FAILURE;
+  }
+  
   this->runTimer();
 
   RCLCPP_INFO(this->get_logger(), "Connected to MG400 at %s", this->ip_address_.c_str());
@@ -129,11 +130,6 @@ CallbackReturn MG400Node::on_deactivate(const State &)
   this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(false));
 
   this->cancelTimer();
-  this->dashboard_api_loader_.reset();
-  this->motion_api_loader_.reset();
-  this->joint_state_pub_.reset();
-  this->robot_mode_pub_.reset();
-  this->error_id_pub_.reset();
   this->interface_->deactivate();
 
   if (this->get_parameter("auto_connect").as_bool()) {
@@ -147,6 +143,11 @@ CallbackReturn MG400Node::on_deactivate(const State &)
 CallbackReturn MG400Node::on_cleanup(const State &)
 {
   this->mg400_connected_pub_.reset();
+  this->dashboard_api_loader_.reset();
+  this->motion_api_loader_.reset();
+  this->joint_state_pub_.reset();
+  this->robot_mode_pub_.reset();
+  this->error_id_pub_.reset();
   this->interface_.reset();
   this->connect_timer_.reset();
   return CallbackReturn::SUCCESS;

--- a/mg400_plugin/src/dashboard_api/acc_j.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_j.cpp
@@ -49,10 +49,12 @@ void AccJ::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->accJ(static_cast<int>(req->r));
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/acc_l.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_l.cpp
@@ -49,10 +49,12 @@ void AccL::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->accL(static_cast<int>(req->r));
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/arch.cpp
+++ b/mg400_plugin/src/dashboard_api/arch.cpp
@@ -48,10 +48,12 @@ void Arch::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->arch(req->index);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/clear_error.cpp
+++ b/mg400_plugin/src/dashboard_api/clear_error.cpp
@@ -49,10 +49,12 @@ void ClearError::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->clearError();
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -48,10 +48,12 @@ void CP::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->cp(req->r);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/di.cpp
+++ b/mg400_plugin/src/dashboard_api/di.cpp
@@ -47,9 +47,12 @@ void DI::onServiceCall(
   const ServiceT::Request::SharedPtr req,
   ServiceT::Response::SharedPtr res)
 {
+  res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       res->result = this->commander_->DI(req->index.index);
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/disable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/disable_robot.cpp
@@ -47,10 +47,12 @@ void DisableRobot::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->disableRobot();
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/do.cpp
+++ b/mg400_plugin/src/dashboard_api/do.cpp
@@ -48,10 +48,12 @@ void DO::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->DO(req->index, req->status);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/emergency_stop.cpp
+++ b/mg400_plugin/src/dashboard_api/emergency_stop.cpp
@@ -49,10 +49,12 @@ void EmergencyStop::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->emergencyStop();
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/enable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/enable_robot.cpp
@@ -47,10 +47,12 @@ void EnableRobot::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->enableRobot();
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/get_angle.cpp
+++ b/mg400_plugin/src/dashboard_api/get_angle.cpp
@@ -47,6 +47,7 @@ void GetAngle::onServiceCall(
   const ServiceT::Request::SharedPtr,
   ServiceT::Response::SharedPtr res)
 {
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       auto joints = this->commander_->getAngle();
@@ -56,6 +57,7 @@ void GetAngle::onServiceCall(
       res->joint4 = joints[3];
       res->joint5 = joints[4];
       res->joint6 = joints[5];
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->error_id = ex.getDashboardResponse().error_id;

--- a/mg400_plugin/src/dashboard_api/get_pose.cpp
+++ b/mg400_plugin/src/dashboard_api/get_pose.cpp
@@ -47,6 +47,7 @@ void GetPose::onServiceCall(
   const ServiceT::Request::SharedPtr,
   ServiceT::Response::SharedPtr res)
 {
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       auto poses = this->commander_->getPose();
@@ -56,6 +57,7 @@ void GetPose::onServiceCall(
       res->pose4 = poses[3];
       res->pose5 = poses[4];
       res->pose6 = poses[5];
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->error_id = ex.getDashboardResponse().error_id;

--- a/mg400_plugin/src/dashboard_api/pay_load.cpp
+++ b/mg400_plugin/src/dashboard_api/pay_load.cpp
@@ -48,10 +48,12 @@ void PayLoad::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->payLoad(req->weight, req->inertia);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/reset_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/reset_robot.cpp
@@ -47,10 +47,12 @@ void ResetRobot::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->resetRobot();
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/robot_mode.cpp
+++ b/mg400_plugin/src/dashboard_api/robot_mode.cpp
@@ -47,9 +47,11 @@ void RobotMode::onServiceCall(
   const ServiceT::Request::SharedPtr,
   ServiceT::Response::SharedPtr res)
 {
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       res->robot_mode.robot_mode = this->commander_->robotMode();
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->error_id = ex.getDashboardResponse().error_id;

--- a/mg400_plugin/src/dashboard_api/set_collision_level.cpp
+++ b/mg400_plugin/src/dashboard_api/set_collision_level.cpp
@@ -48,10 +48,12 @@ void SetCollisionLevel::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->setCollisionLevel(req->level);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/speed_factor.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_factor.cpp
@@ -47,10 +47,12 @@ void SpeedFactor::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->speedFactor(static_cast<int>(req->ratio));
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/speed_j.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_j.cpp
@@ -49,10 +49,12 @@ void SpeedJ::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->speedJ(static_cast<int>(req->r));
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/speed_l.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_l.cpp
@@ -49,10 +49,12 @@ void SpeedL::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->speedL(static_cast<int>(req->r));
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/tool.cpp
+++ b/mg400_plugin/src/dashboard_api/tool.cpp
@@ -47,10 +47,12 @@ void Tool::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->tool(req->tool);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
+++ b/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
@@ -48,11 +48,13 @@ void ToolDOExecute::onServiceCall(
 )
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->toolDOExecute(
         req->index, req->status);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;

--- a/mg400_plugin/src/dashboard_api/user.cpp
+++ b/mg400_plugin/src/dashboard_api/user.cpp
@@ -47,10 +47,12 @@ void User::onServiceCall(
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
+  res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
       this->commander_->user(req->user);
       res->result = true;
+      res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
       res->result = false;


### PR DESCRIPTION
When packaging the ros2 packages of this repository and its mg400_node, mg400_node gets segmentation fault when reconnecting to MG400. There is no error at the first connection. In addition, this doesn't happen when building locally with colcon build.

The cause of this error is not clear yet, but to avoid this for now, this PR moves the steps of loading plugins etc (which causes the segmentation fault) from `on_activate` to `on_configure` and keep them even after disconnecting from MG400.