### PR TITLE
Add SetCollisionLevel to the default plugin

### DIFF
--- a/mg400_node/README.md
+++ b/mg400_node/README.md
@@ -15,6 +15,7 @@ The following API interface plugin will be loaded by default
   - `EnableRobot`
   - `PayLoad`
   - `ResetRobot`
+  - `SetCollisionLevel`
   - `SpeedFactor`
   - `ToolDOExecute`
 - Motion API

--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -44,6 +44,7 @@ private:
     "mg400_plugin::EnableRobot",
     "mg400_plugin::PayLoad",
     "mg400_plugin::ResetRobot",
+    "mg400_plugin::SetCollisionLevel",
     "mg400_plugin::SpeedFactor",
     "mg400_plugin::ToolDOExecute"
   };


### PR DESCRIPTION
As title says, this PR adds `SetCollisionLevel` to the default plugin of mg400 node.