### PR TITLE
Add `error_code` in DashboardResponse

### DIFF
--- a/mg400_interface/include/mg400_interface/commander/response_parser.hpp
+++ b/mg400_interface/include/mg400_interface/commander/response_parser.hpp
@@ -27,7 +27,7 @@ namespace mg400_interface
 {
 typedef struct
 {
-  bool result;
+  int error_code;
   std::string ret_val;
   std::string func_name;
 } DashboardResponse;

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -88,8 +88,8 @@ uint64_t DashboardCommander::robotMode() const
   static DashboardResponse response;
   ResponseParser::parseResponse(
     this->sendAndWaitResponse("RobotMode()"), response);
-  if (!response.result) {
-    throw std::runtime_error("Dobot not return 0");
+  if (response.error_code != 0) {
+    throw std::runtime_error("Dobot not return 0: " + std::to_string(response.error_code));
   }
   return static_cast<uint64_t>(ResponseParser::takeInt(response.ret_val));
 }
@@ -223,8 +223,8 @@ std::vector<double> DashboardCommander::getAngle()
   static DashboardResponse response;
   ResponseParser::parseResponse(
     this->sendAndWaitResponse("GetAngle()"), response);
-  if (!response.result) {
-    throw std::runtime_error("Dobot not return 0");
+  if (response.error_code != 0) {
+    throw std::runtime_error("Dobot not return 0: " + std::to_string(response.error_code));
   }
   return ResponseParser::takeAngleArray(response.ret_val);
 }
@@ -234,8 +234,8 @@ std::vector<double> DashboardCommander::getPose()
   static DashboardResponse response;
   ResponseParser::parseResponse(
     this->sendAndWaitResponse("GetPose()"), response);
-  if (!response.result) {
-    throw std::runtime_error("Dobot not return 0");
+  if (response.error_code != 0) {
+    throw std::runtime_error("Dobot not return 0: " + std::to_string(response.error_code));
   }
   return ResponseParser::takePoseArray(response.ret_val);
 }
@@ -351,8 +351,8 @@ std::array<std::vector<int>, 6> DashboardCommander::getErrorId() const
   static DashboardResponse response;
   ResponseParser::parseResponse(
     this->sendAndWaitResponse("GetErrorID()"), response);
-  if (!response.result) {
-    throw std::runtime_error("Dobot Not return 0");
+  if (response.error_code != 0) {
+    throw std::runtime_error("Dobot Not return 0: " + std::to_string(response.error_code));
   }
   return ResponseParser::takeErrorMessage(response.ret_val);
 }
@@ -369,8 +369,8 @@ int DashboardCommander::DI(const DIIndex::_index_type & di_index) const
   const int cx = snprintf(buf, sizeof(buf), "DI(%u)", di_index);
   ResponseParser::parseResponse(
     this->sendAndWaitResponse(std::string(buf, cx)), response);
-  if (!response.result) {
-    throw std::runtime_error("Dobot Not return 0");
+  if (response.error_code != 0) {
+    throw std::runtime_error("Dobot Not return 0: " + std::to_string(response.error_code));
   }
   return ResponseParser::takeInt(response.ret_val);
 }
@@ -402,8 +402,8 @@ void DashboardCommander::evaluateResponse(const std::string & packet) const
 {
   static DashboardResponse response;
   ResponseParser::parseResponse(packet, response);
-  if (!response.result) {
-    throw std::runtime_error("Dobot Not return 0");
+  if (response.error_code != 0) {
+    throw std::runtime_error("Dobot Not return 0: " + std::to_string(response.error_code));
   }
 }
 }  // namespace mg400_interface

--- a/mg400_interface/src/commander/response_parser.cpp
+++ b/mg400_interface/src/commander/response_parser.cpp
@@ -28,7 +28,7 @@ bool ResponseParser::parseResponse(
     switch (search_mode_counter) {
       case 0:
         if (s == ',') {
-          response.result = std::stoi(buf) == 0;
+          response.error_code = std::stoi(buf);
           buf.clear();
           // go to next search mode
           search_mode_counter++;

--- a/mg400_interface/test/src/commander/test_response_parser.cpp
+++ b/mg400_interface/test/src/commander/test_response_parser.cpp
@@ -21,7 +21,7 @@ TEST(ResponseParser, ParseResponse) {
   mg400_interface::DashboardResponse response;
   mg400_interface::ResponseParser::parseResponse(packet, response);
 
-  ASSERT_TRUE(response.result);
+  ASSERT_EQ(response.error_code, 0);
   ASSERT_EQ(response.ret_val, "{5}");
   ASSERT_EQ(response.func_name, "RobotMode()");
 }


### PR DESCRIPTION
When dashboard command fails with non zero return code, current implementation doesn't show anything about the error code itself. This PR updates MG400Interface and print the error code.