### PR TITLE
Add `error_id` to `MovJ` and `MovL` action message

### DIFF
--- a/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
+++ b/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
@@ -25,6 +25,7 @@
 #include <mg400_msgs/msg/di_index.hpp>
 #include <mg400_msgs/msg/do_index.hpp>
 #include <mg400_msgs/msg/do_status.hpp>
+#include <mg400_msgs/msg/error_id.hpp>
 #include <mg400_msgs/msg/tool_do_index.hpp>
 #include <mg400_msgs/msg/tool.hpp>
 #include <mg400_msgs/msg/user.hpp>
@@ -51,6 +52,7 @@ private:
   using DIIndex = mg400_msgs::msg::DIIndex;
   using DOIndex = mg400_msgs::msg::DOIndex;
   using DOStatus = mg400_msgs::msg::DOStatus;
+  using ErrorID = mg400_msgs::msg::ErrorID;
   using Tool = mg400_msgs::msg::Tool;
   using ToolDOIndex = mg400_msgs::msg::ToolDOIndex;
   using User = mg400_msgs::msg::User;
@@ -147,6 +149,7 @@ public:
   int setHoldRegs(const int, const int, const int, const std::string &, const std::string &);
 */
   std::array<std::vector<int>, 6> getErrorId() const;
+  void convertToErrorIdMsg(const std::array<std::vector<int>, 6> &, ErrorID &) const;
 
   int DI(const DIIndex &) const;
   int DI(const DIIndex::_index_type &) const;

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -363,7 +363,7 @@ void DashboardCommander::convertToErrorIdMsg(
 {
   msg.controller.ids = error_id.at(0);
   for (size_t i = 1; i < error_id.size(); ++i) {
-    msg.servo.at(i-1).ids = error_id[i];
+    msg.servo.at(i - 1).ids = error_id[i];
   }
 }
 

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -357,6 +357,16 @@ std::array<std::vector<int>, 6> DashboardCommander::getErrorId() const
   return ResponseParser::takeErrorMessage(response.ret_val);
 }
 
+void DashboardCommander::convertToErrorIdMsg(
+  const std::array<std::vector<int>, 6> & error_id,
+  ErrorID & msg) const
+{
+  msg.controller.ids = error_id.at(0);
+  for (size_t i = 1; i < error_id.size(); ++i) {
+    msg.servo.at(i-1).ids = error_id[i];
+  }
+}
+
 int DashboardCommander::DI(const DIIndex & do_index) const
 {
   return this->DI(do_index.index);

--- a/mg400_msgs/action/MovJ.action
+++ b/mg400_msgs/action/MovJ.action
@@ -3,6 +3,7 @@ geometry_msgs/PoseStamped pose
 ---
 #result definition
 bool result
+mg400_msgs/ErrorID error_id
 ---
 #feedback definition
 geometry_msgs/PoseStamped current_pose

--- a/mg400_msgs/action/MovL.action
+++ b/mg400_msgs/action/MovL.action
@@ -3,6 +3,7 @@ geometry_msgs/PoseStamped pose
 ---
 #result definition
 bool result
+mg400_msgs/ErrorID error_id
 ---
 #feedback definition
 geometry_msgs/PoseStamped current_pose

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -189,9 +189,12 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(),
         "execution timeout: Robot mode did not become RUNNING.");
-      try{
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      try {
+        const std::array<std::vector<int>,
+          6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id,
+          result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -203,8 +206,10 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -221,8 +226,10 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (!this->mg400_interface_->ok()) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 Connection Error");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -234,8 +241,10 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking goal");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -246,8 +255,10 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (this->node_clock_if_->get_clock()->now() - start > timeout) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -189,6 +189,12 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(),
         "execution timeout: Robot mode did not become RUNNING.");
+      try{
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
@@ -196,6 +202,12 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
@@ -208,6 +220,12 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   {
     if (!this->mg400_interface_->ok()) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 Connection Error");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
@@ -215,12 +233,24 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking goal");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
 
     if (this->node_clock_if_->get_clock()->now() - start > timeout) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -82,25 +82,6 @@ rclcpp_action::GoalResponse MovJ::handle_goal(
     return rclcpp_action::GoalResponse::REJECT;
   }
 
-  std::vector<double> tool_vec;
-  tool_vec.push_back(this->tf_goal_.pose.position.x);  // px
-  tool_vec.push_back(this->tf_goal_.pose.position.y);  // py
-  tool_vec.push_back(this->tf_goal_.pose.position.z);  // pz
-  tool_vec.push_back(tf2::getYaw(this->tf_goal_.pose.orientation));  // r in radian
-
-  // check if the requested goal is inside the mg400 range
-  // by solving inverse kinematics and see the angles of each joints.
-  std::vector<double> angles;
-  try {
-    angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
-    RCLCPP_INFO(
-      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
-      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
-    return rclcpp_action::GoalResponse::REJECT;
-  }
-
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
@@ -131,6 +112,29 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   auto result = std::make_shared<ActionT::Result>();
   result->result = false;
 
+  // check if the requested goal is inside the mg400 range
+  // by solving inverse kinematics and see the angles of each joints.
+  std::vector<double> tool_vec;
+  tool_vec.push_back(this->tf_goal_.pose.position.x);  // px
+  tool_vec.push_back(this->tf_goal_.pose.position.y);  // py
+  tool_vec.push_back(this->tf_goal_.pose.position.z);  // pz
+  tool_vec.push_back(tf2::getYaw(this->tf_goal_.pose.orientation));  // r in radian
+  std::vector<double> angles;
+  try {
+    angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
+    RCLCPP_INFO(
+      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
+      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
+    // ErrorID 18: Inverse kinematics error with result out of working area
+    result->result = false;
+    result->error_id.controller.ids.emplace_back(18);
+    goal_handle->abort(result);
+    return;
+  }
+
+  // send MovJ command
   try {
     this->commander_->movJ(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -82,25 +82,6 @@ rclcpp_action::GoalResponse MovL::handle_goal(
     return rclcpp_action::GoalResponse::REJECT;
   }
 
-  std::vector<double> tool_vec;
-  tool_vec.push_back(this->tf_goal_.pose.position.x);  // px
-  tool_vec.push_back(this->tf_goal_.pose.position.y);  // py
-  tool_vec.push_back(this->tf_goal_.pose.position.z);  // pz
-  tool_vec.push_back(tf2::getYaw(this->tf_goal_.pose.orientation));  // r in radian
-
-  // check if the requested goal is inside the mg400 range
-  // by solving inverse kinematics and see the angles of each joints.
-  std::vector<double> angles;
-  try {
-    angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
-    RCLCPP_INFO(
-      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
-      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
-    return rclcpp_action::GoalResponse::REJECT;
-  }
-
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
@@ -131,6 +112,29 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   auto result = std::make_shared<ActionT::Result>();
   result->result = false;
 
+  // check if the requested goal is inside the mg400 range
+  // by solving inverse kinematics and see the angles of each joints.
+  std::vector<double> tool_vec;
+  tool_vec.push_back(this->tf_goal_.pose.position.x);  // px
+  tool_vec.push_back(this->tf_goal_.pose.position.y);  // py
+  tool_vec.push_back(this->tf_goal_.pose.position.z);  // pz
+  tool_vec.push_back(tf2::getYaw(this->tf_goal_.pose.orientation));  // r in radian
+  std::vector<double> angles;
+  try {
+    angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
+    RCLCPP_INFO(
+      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
+      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
+    // ErrorID 18: Inverse kinematics error with result out of working area
+    result->result = false;
+    result->error_id.controller.ids.emplace_back(18);
+    goal_handle->abort(result);
+    return;
+  }
+
+  // send MovL command
   try {
     this->commander_->movL(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -189,6 +189,12 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(),
         "execution timeout: Robot mode did not become RUNNING.");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
@@ -196,6 +202,12 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
@@ -208,6 +220,12 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   {
     if (!this->mg400_interface_->ok()) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 Connection Error");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
@@ -215,12 +233,24 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (this->mg400_interface_->realtime_tcp_interface->isRobotMode(RobotMode::ERROR)) {
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking reaching goal");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }
 
     if (this->node_clock_if_->get_clock()->now() - start > timeout) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
+      try {
+        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
+      }
       goal_handle->abort(result);
       return;
     }

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -190,8 +190,10 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
         this->node_logging_if_->get_logger(),
         "execution timeout: Robot mode did not become RUNNING.");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -203,8 +205,10 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking becoming RUNNING");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -221,8 +225,10 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (!this->mg400_interface_->ok()) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 Connection Error");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -234,8 +240,10 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
       RCLCPP_ERROR(
         this->node_logging_if_->get_logger(), "Robot Mode Error while checking reaching goal");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }
@@ -246,8 +254,10 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     if (this->node_clock_if_->get_clock()->now() - start > timeout) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), "execution timeout");
       try {
-        const std::array<std::vector<int>, 6> error_id = this->mg400_interface_->dashboard_commander->getErrorId();
-        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(error_id, result->error_id);
+        const std::array<std::vector<int>, 6> error_id =
+          this->mg400_interface_->dashboard_commander->getErrorId();
+        this->mg400_interface_->dashboard_commander->convertToErrorIdMsg(
+          error_id, result->error_id);
       } catch (const std::exception & e) {
         RCLCPP_WARN(this->node_logging_if_->get_logger(), "Failed to get Error ID: %s", e.what());
       }


### PR DESCRIPTION
Previous action message of `MovJ` and `MovL` returns only bool value (success or failure) and doesn't provide what is wrong with it. To provide more detailed information about the action, this PR updates the action message definition and `MovJ` and `MovL` return `ErrorID` when it fails.

In addition, previous implementation rejected action request if the goal position is outside of the MG400 range. But since it is difficult to return detailed information when rejection action request, this PR changed it to abort the action when IK fails.