### PR TITLE
Add `error_id` to dashboard command response

### DIFF
--- a/mg400_interface/include/mg400_interface/commander/response_parser.hpp
+++ b/mg400_interface/include/mg400_interface/commander/response_parser.hpp
@@ -39,9 +39,8 @@ private:
   std::string error_message_;
 
 public:
-  explicit DashboardCommandException(
-    const std::string & msg, const DashboardResponse & response)
-  : std::runtime_error(msg),
+  explicit DashboardCommandException(const DashboardResponse & response)
+  : std::runtime_error("DashboardCommandException"),
     response_(response)
   {
     this->error_message_ = response_.func_name + " failed: " +

--- a/mg400_interface/include/mg400_interface/commander/response_parser.hpp
+++ b/mg400_interface/include/mg400_interface/commander/response_parser.hpp
@@ -32,6 +32,32 @@ typedef struct
   std::string func_name;
 } DashboardResponse;
 
+class DashboardCommandException : public std::runtime_error
+{
+private:
+  DashboardResponse response_;
+  std::string error_message_;
+
+public:
+  explicit DashboardCommandException(
+    const std::string & msg, const DashboardResponse & response)
+  : std::runtime_error(msg),
+    response_(response)
+  {
+    this->error_message_ = response_.func_name + " failed: "
+      + std::to_string(response_.error_id) + " " + response_.ret_val;
+  }
+
+  const DashboardResponse & getDashboardResponse() const {
+    return response_;
+  }
+
+  const char* what() const noexcept override
+  {
+    return this->error_message_.c_str();
+  }
+};
+
 class ResponseParser
 {
 public:

--- a/mg400_interface/include/mg400_interface/commander/response_parser.hpp
+++ b/mg400_interface/include/mg400_interface/commander/response_parser.hpp
@@ -44,15 +44,16 @@ public:
   : std::runtime_error(msg),
     response_(response)
   {
-    this->error_message_ = response_.func_name + " failed: "
-      + std::to_string(response_.error_id) + " " + response_.ret_val;
+    this->error_message_ = response_.func_name + " failed: " +
+      std::to_string(response_.error_id) + " " + response_.ret_val;
   }
 
-  const DashboardResponse & getDashboardResponse() const {
+  const DashboardResponse & getDashboardResponse() const
+  {
     return response_;
   }
 
-  const char* what() const noexcept override
+  const char * what() const noexcept override
   {
     return this->error_message_.c_str();
   }

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -413,7 +413,7 @@ void DashboardCommander::evaluateResponse(const std::string & packet) const
   static DashboardResponse response;
   ResponseParser::parseResponse(packet, response);
   if (response.error_id != 0) {
-    throw std::runtime_error("Dobot Not return 0: " + std::to_string(response.error_id));
+    throw DashboardCommandException("Dobot Not return 0", response);
   }
 }
 }  // namespace mg400_interface

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -413,7 +413,7 @@ void DashboardCommander::evaluateResponse(const std::string & packet) const
   static DashboardResponse response;
   ResponseParser::parseResponse(packet, response);
   if (response.error_id != 0) {
-    throw DashboardCommandException("Dobot Not return 0", response);
+    throw DashboardCommandException(response);
   }
 }
 }  // namespace mg400_interface

--- a/mg400_msgs/srv/AccJ.srv
+++ b/mg400_msgs/srv/AccJ.srv
@@ -1,3 +1,4 @@
 uint8 r
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/AccL.srv
+++ b/mg400_msgs/srv/AccL.srv
@@ -1,3 +1,4 @@
 uint8 r
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/Arch.srv
+++ b/mg400_msgs/srv/Arch.srv
@@ -1,3 +1,4 @@
 mg400_msgs/Arch index
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/CP.srv
+++ b/mg400_msgs/srv/CP.srv
@@ -1,3 +1,4 @@
 uint16 r
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/ClearError.srv
+++ b/mg400_msgs/srv/ClearError.srv
@@ -1,2 +1,3 @@
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/DI.srv
+++ b/mg400_msgs/srv/DI.srv
@@ -1,3 +1,4 @@
 mg400_msgs/DIIndex index
 ---
 uint8 result
+int32 error_id

--- a/mg400_msgs/srv/DO.srv
+++ b/mg400_msgs/srv/DO.srv
@@ -2,3 +2,4 @@ mg400_msgs/DOIndex index
 mg400_msgs/DOStatus status
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/DisableRobot.srv
+++ b/mg400_msgs/srv/DisableRobot.srv
@@ -1,2 +1,3 @@
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/EmergencyStop.srv
+++ b/mg400_msgs/srv/EmergencyStop.srv
@@ -1,2 +1,3 @@
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/EnableRobot.srv
+++ b/mg400_msgs/srv/EnableRobot.srv
@@ -1,2 +1,3 @@
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/GetAngle.srv
+++ b/mg400_msgs/srv/GetAngle.srv
@@ -1,4 +1,5 @@
 ---
+int32 error_id
 float64 joint1
 float64 joint2
 float64 joint3

--- a/mg400_msgs/srv/GetPose.srv
+++ b/mg400_msgs/srv/GetPose.srv
@@ -1,4 +1,5 @@
 ---
+int32 error_id
 float64 pose1
 float64 pose2
 float64 pose3

--- a/mg400_msgs/srv/JointMovJ.srv
+++ b/mg400_msgs/srv/JointMovJ.srv
@@ -5,3 +5,4 @@ float64 j4
 float64 j5
 float64 j6
 ---
+int32 error_id

--- a/mg400_msgs/srv/MoveJog.srv
+++ b/mg400_msgs/srv/MoveJog.srv
@@ -1,2 +1,3 @@
 mg400_msgs/MoveJog jog
 ---
+int32 error_id

--- a/mg400_msgs/srv/PayLoad.srv
+++ b/mg400_msgs/srv/PayLoad.srv
@@ -2,3 +2,4 @@ float64 weight
 float64 inertia
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/ResetRobot.srv
+++ b/mg400_msgs/srv/ResetRobot.srv
@@ -1,2 +1,3 @@
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/RobotMode.srv
+++ b/mg400_msgs/srv/RobotMode.srv
@@ -1,2 +1,3 @@
 ---
 mg400_msgs/RobotMode robot_mode
+int32 error_id

--- a/mg400_msgs/srv/SetCollisionLevel.srv
+++ b/mg400_msgs/srv/SetCollisionLevel.srv
@@ -1,3 +1,4 @@
 mg400_msgs/CollisionLevel level
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/SpeedFactor.srv
+++ b/mg400_msgs/srv/SpeedFactor.srv
@@ -1,3 +1,4 @@
 uint8 ratio
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/SpeedJ.srv
+++ b/mg400_msgs/srv/SpeedJ.srv
@@ -1,3 +1,4 @@
 uint8 r
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/SpeedL.srv
+++ b/mg400_msgs/srv/SpeedL.srv
@@ -1,3 +1,4 @@
 uint8 r
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/Tool.srv
+++ b/mg400_msgs/srv/Tool.srv
@@ -1,3 +1,4 @@
 mg400_msgs/Tool tool
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/ToolDOExecute.srv
+++ b/mg400_msgs/srv/ToolDOExecute.srv
@@ -2,3 +2,4 @@ mg400_msgs/ToolDOIndex index
 mg400_msgs/DOStatus status
 ---
 bool result
+int32 error_id

--- a/mg400_msgs/srv/User.srv
+++ b/mg400_msgs/srv/User.srv
@@ -1,3 +1,4 @@
 mg400_msgs/User user
 ---
 bool result
+int32 error_id

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -254,7 +254,7 @@ void MG400Node::onErrorTimer()
   } catch (const std::out_of_range & ex) {
     RCLCPP_ERROR(this->get_logger(), "Out of range %s", ex.what());
   } catch (...) {
-    RCLCPP_ERROR(this->get_logger(), "Unknown exception");
+    RCLCPP_ERROR(this->get_logger(), "Cannot parse response from MG400");
   }
 }
 

--- a/mg400_plugin/src/dashboard_api/acc_j.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_j.cpp
@@ -53,6 +53,10 @@ void AccJ::onServiceCall(
     try {
       this->commander_->accJ(static_cast<int>(req->r));
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/acc_l.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_l.cpp
@@ -53,6 +53,10 @@ void AccL::onServiceCall(
     try {
       this->commander_->accL(static_cast<int>(req->r));
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/arch.cpp
+++ b/mg400_plugin/src/dashboard_api/arch.cpp
@@ -52,6 +52,10 @@ void Arch::onServiceCall(
     try {
       this->commander_->arch(req->index);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/clear_error.cpp
+++ b/mg400_plugin/src/dashboard_api/clear_error.cpp
@@ -53,6 +53,10 @@ void ClearError::onServiceCall(
     try {
       this->commander_->clearError();
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -52,6 +52,10 @@ void CP::onServiceCall(
     try {
       this->commander_->cp(req->r);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/di.cpp
+++ b/mg400_plugin/src/dashboard_api/di.cpp
@@ -50,6 +50,10 @@ void DI::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       res->result = this->commander_->DI(req->index.index);
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/disable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/disable_robot.cpp
@@ -51,6 +51,10 @@ void DisableRobot::onServiceCall(
     try {
       this->commander_->disableRobot();
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/do.cpp
+++ b/mg400_plugin/src/dashboard_api/do.cpp
@@ -52,6 +52,10 @@ void DO::onServiceCall(
     try {
       this->commander_->DO(req->index, req->status);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/emergency_stop.cpp
+++ b/mg400_plugin/src/dashboard_api/emergency_stop.cpp
@@ -53,6 +53,10 @@ void EmergencyStop::onServiceCall(
     try {
       this->commander_->emergencyStop();
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/enable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/enable_robot.cpp
@@ -51,6 +51,10 @@ void EnableRobot::onServiceCall(
     try {
       this->commander_->enableRobot();
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/get_angle.cpp
+++ b/mg400_plugin/src/dashboard_api/get_angle.cpp
@@ -56,6 +56,9 @@ void GetAngle::onServiceCall(
       res->joint4 = joints[3];
       res->joint5 = joints[4];
       res->joint6 = joints[5];
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/get_pose.cpp
+++ b/mg400_plugin/src/dashboard_api/get_pose.cpp
@@ -56,6 +56,9 @@ void GetPose::onServiceCall(
       res->pose4 = poses[3];
       res->pose5 = poses[4];
       res->pose6 = poses[5];
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/pay_load.cpp
+++ b/mg400_plugin/src/dashboard_api/pay_load.cpp
@@ -52,6 +52,10 @@ void PayLoad::onServiceCall(
     try {
       this->commander_->payLoad(req->weight, req->inertia);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/reset_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/reset_robot.cpp
@@ -51,6 +51,10 @@ void ResetRobot::onServiceCall(
     try {
       this->commander_->resetRobot();
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/robot_mode.cpp
+++ b/mg400_plugin/src/dashboard_api/robot_mode.cpp
@@ -50,6 +50,9 @@ void RobotMode::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       res->robot_mode.robot_mode = this->commander_->robotMode();
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/set_collision_level.cpp
+++ b/mg400_plugin/src/dashboard_api/set_collision_level.cpp
@@ -52,6 +52,10 @@ void SetCollisionLevel::onServiceCall(
     try {
       this->commander_->setCollisionLevel(req->level);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/speed_factor.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_factor.cpp
@@ -51,6 +51,10 @@ void SpeedFactor::onServiceCall(
     try {
       this->commander_->speedFactor(static_cast<int>(req->ratio));
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/speed_j.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_j.cpp
@@ -53,6 +53,10 @@ void SpeedJ::onServiceCall(
     try {
       this->commander_->speedJ(static_cast<int>(req->r));
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/speed_l.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_l.cpp
@@ -53,6 +53,10 @@ void SpeedL::onServiceCall(
     try {
       this->commander_->speedL(static_cast<int>(req->r));
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/tool.cpp
+++ b/mg400_plugin/src/dashboard_api/tool.cpp
@@ -51,6 +51,10 @@ void Tool::onServiceCall(
     try {
       this->commander_->tool(req->tool);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
+++ b/mg400_plugin/src/dashboard_api/tool_do_execute.cpp
@@ -53,6 +53,10 @@ void ToolDOExecute::onServiceCall(
       this->commander_->toolDOExecute(
         req->index, req->status);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {

--- a/mg400_plugin/src/dashboard_api/user.cpp
+++ b/mg400_plugin/src/dashboard_api/user.cpp
@@ -51,6 +51,10 @@ void User::onServiceCall(
     try {
       this->commander_->user(req->user);
       res->result = true;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
     } catch (const std::runtime_error & ex) {
       RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
     } catch (...) {


### PR DESCRIPTION
Like #262 , this PR adds `error_id` to dashboard command response (ROS2 service message) for more detailed information about the error.