### PR TITLE
Support parameters in EnableRobot command

### DIFF
--- a/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
+++ b/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
@@ -68,7 +68,12 @@ public:
     const std::chrono::nanoseconds = 5s);
 
   // DOBOT MG400 Official Command ---------------------------------------------
-  void enableRobot() const;
+  void enableRobot(
+    const int8_t = 0,
+    const double = 0,
+    const double = 0,
+    const double = 0,
+    const double = 0) const;
 
   void disableRobot() const;
 

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -28,10 +28,33 @@ DashboardCommander::DashboardCommander(
 }
 
 // DOBOT MG400 Official Command ---------------------------------------------
-void DashboardCommander::enableRobot() const
+void DashboardCommander::enableRobot(
+  const int8_t num_of_params,
+  const double load,
+  const double center_x,
+  const double center_y,
+  const double center_z) const
 {
-  this->evaluateResponse(
-    this->sendAndWaitResponse("EnableRobot()"));
+  if (num_of_params == 0) {
+    this->evaluateResponse(
+      this->sendAndWaitResponse("EnableRobot()"));
+  } else if (num_of_params == 1) {
+    static char buf[128];
+    const int cx = snprintf(buf, sizeof(buf), "EnableRobot(%.3lf)", load);
+    this->evaluateResponse(this->sendAndWaitResponse(std::string(buf, cx)));
+  } else if (num_of_params == 4) {
+    static char buf[128];
+    const int cx = snprintf(
+      buf, sizeof(buf), "EnableRobot(%.3lf,%.3lf,%.3lf,%.3lf)",
+      load, center_x, center_y, center_z);
+    this->evaluateResponse(this->sendAndWaitResponse(std::string(buf, cx)));
+  } else {
+    mg400_interface::DashboardResponse response;
+    response.error_id = -1;
+    response.ret_val = "Invalid number of parameters.";
+    response.func_name = "EnableRobot";
+    throw mg400_interface::DashboardCommandException(response);
+  }
 }
 
 void DashboardCommander::disableRobot() const

--- a/mg400_msgs/srv/EnableRobot.srv
+++ b/mg400_msgs/srv/EnableRobot.srv
@@ -1,3 +1,12 @@
+int8 NO_PARAMETER=0
+int8 ONE_PARAMETER=1
+int8 FOUR_PARAMETER=4
+
+int8 num_of_params
+float64 load
+float64 center_x
+float64 center_y
+float64 center_z
 ---
 bool result
 int32 error_id

--- a/mg400_msgs/srv/EnableRobot.srv
+++ b/mg400_msgs/srv/EnableRobot.srv
@@ -1,6 +1,6 @@
-int8 NO_PARAMETER=0
-int8 ONE_PARAMETER=1
-int8 FOUR_PARAMETER=4
+int8 NO_PARAM=0
+int8 ONE_PARAM=1
+int8 FOUR_PARAM=4
 
 int8 num_of_params
 float64 load

--- a/mg400_plugin/src/dashboard_api/enable_robot.cpp
+++ b/mg400_plugin/src/dashboard_api/enable_robot.cpp
@@ -43,14 +43,15 @@ void EnableRobot::configure(
 }
 
 void EnableRobot::onServiceCall(
-  const ServiceT::Request::SharedPtr,
+  const ServiceT::Request::SharedPtr req,
   ServiceT::Response::SharedPtr res)
 {
   res->result = false;
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->enableRobot();
+      this->commander_->enableRobot(
+        req->num_of_params, req->load, req->center_x, req->center_y, req->center_z);
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {


### PR DESCRIPTION
`EnableRobot` command supports multiple parameters option which sets load parameters. This option is required to properly set the load parameter. (If you send `EnableRobot()` without specifying load parameters, MG400 sometimes changes it).

![image](https://github.com/user-attachments/assets/cde0c4bf-70c2-467b-a5bf-0a7067a01e9d)

To support this feature in MG400_ROS2, this PR updates message definition and dashboard commander.