### PR TITLE
Use `connection_interrupted_flag` to simplify reconnection handling in mg400_node

### DIFF
--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -72,6 +72,8 @@ private:
   rclcpp::Publisher<mg400_msgs::msg::ErrorID>::SharedPtr error_id_pub_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr mg400_connected_pub_;
 
+  bool connection_interrupted_;
+
 public:
   MG400Node() = delete;
   explicit MG400Node(const rclcpp::NodeOptions &);

--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -59,14 +59,12 @@ private:
   mg400_interface::MG400Interface::SharedPtr interface_;
   mg400_plugin_base::DashboardApiLoader::SharedPtr dashboard_api_loader_;
   mg400_plugin_base::MotionApiLoader::SharedPtr motion_api_loader_;
-  bool mg400_connected_;
 
   rclcpp::TimerBase::SharedPtr init_timer_;
   rclcpp::TimerBase::SharedPtr joint_state_timer_;
   rclcpp::TimerBase::SharedPtr robot_mode_timer_;
   rclcpp::TimerBase::SharedPtr error_timer_;
   rclcpp::TimerBase::SharedPtr interface_check_timer_;
-  rclcpp::TimerBase::SharedPtr activate_timer_;
   rclcpp::TimerBase::SharedPtr connect_timer_;
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
@@ -93,7 +91,6 @@ private:
   CallbackReturn on_shutdown(const rclcpp_lifecycle::State &) override;
   CallbackReturn on_error(const rclcpp_lifecycle::State &) override;
 
-  void connect();
   void runTimer();
   void cancelTimer();
 };

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -271,6 +271,7 @@ void MG400Node::onErrorTimer()
 void MG400Node::onInterfaceCheckTimer()
 {
   if (!this->interface_->ok()) {
+    RCLCPP_ERROR(this->get_logger(), "Connection to MG400 was interrupted");
     this->connection_interrupted_ = true;
     this->deactivate();
   }

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -95,6 +95,8 @@ CallbackReturn MG400Node::on_configure(const State &)
     "robot_mode", rclcpp::SensorDataQoS());
   this->error_id_pub_ = this->create_publisher<mg400_msgs::msg::ErrorID>(
     "error_id", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().durability_volatile());
+  
+  this->connection_interrupted_ = false;
 
   if (this->get_parameter("auto_connect").as_bool()) {
     RCLCPP_INFO(this->get_logger(), "Try connecting to MG400 at %s ...", this->ip_address_.c_str());
@@ -110,7 +112,7 @@ CallbackReturn MG400Node::on_activate(const State &)
 
   if (!this->interface_->activate()) {
     RCLCPP_WARN(this->get_logger(), "Failed to connect to MG400 at %s", this->ip_address_.c_str());
-    if (this->get_parameter("auto_connect").as_bool()) {
+    if (this->get_parameter("auto_connect").as_bool() || this->connection_interrupted_) {
       RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
       this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
     }
@@ -118,6 +120,7 @@ CallbackReturn MG400Node::on_activate(const State &)
   }
 
   this->runTimer();
+  this->connection_interrupted_ = false;
 
   RCLCPP_INFO(this->get_logger(), "Connected to MG400 at %s", this->ip_address_.c_str());
   this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(true));
@@ -131,6 +134,11 @@ CallbackReturn MG400Node::on_deactivate(const State &)
 
   this->cancelTimer();
   this->interface_->deactivate();
+
+  if (this->connection_interrupted_) {
+    RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
+    this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});   
+  }
 
   return CallbackReturn::SUCCESS;
 }
@@ -263,6 +271,7 @@ void MG400Node::onErrorTimer()
 void MG400Node::onInterfaceCheckTimer()
 {
   if (!this->interface_->ok()) {
+    this->connection_interrupted_ = true;
     this->deactivate();
   }
 }

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -46,11 +46,10 @@ MG400Node::~MG400Node()
 
 CallbackReturn MG400Node::on_configure(const State &)
 {
-  this->mg400_connected_ = false;
   this->mg400_connected_pub_ =
     this->create_publisher<std_msgs::msg::Bool>(
     "mg400_connected", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local());
-  this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(this->mg400_connected_));
+  this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(false));
 
   this->ip_address_ = this->get_parameter("ip_address").as_string();
   this->interface_ =
@@ -99,7 +98,7 @@ CallbackReturn MG400Node::on_configure(const State &)
 
   if (this->get_parameter("auto_connect").as_bool()) {
     RCLCPP_INFO(this->get_logger(), "Try connecting to MG400 at %s ...", this->ip_address_.c_str());
-    this->activate_timer_ = this->create_wall_timer(0s, [this]() {this->activate();});
+    this->connect_timer_ = this->create_wall_timer(0s, [this]() {this->activate();});
   }
 
   return CallbackReturn::SUCCESS;
@@ -107,23 +106,31 @@ CallbackReturn MG400Node::on_configure(const State &)
 
 CallbackReturn MG400Node::on_activate(const State &)
 {
-  this->activate_timer_.reset();
-  this->connect_timer_ = this->create_wall_timer(0s, [this]() {this->connect();});
+  this->connect_timer_.reset();
+
+  if (!this->interface_->activate()) {
+    RCLCPP_WARN(this->get_logger(), "Failed to connect to MG400 at %s", this->ip_address_.c_str());
+    if (this->get_parameter("auto_connect").as_bool()) {
+      RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
+      this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
+    }
+    return CallbackReturn::FAILURE;
+  }
+
+  this->runTimer();
+
+  RCLCPP_INFO(this->get_logger(), "Connected to MG400 at %s", this->ip_address_.c_str());
+  this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(true));
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn MG400Node::on_deactivate(const State &)
 {
-  this->connect_timer_.reset();
+  RCLCPP_WARN(this->get_logger(), "Disconnected from MG400 at %s", this->ip_address_.c_str());
+  this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(false));
 
   this->cancelTimer();
   this->interface_->deactivate();
-
-  if (this->mg400_connected_) {
-    this->mg400_connected_ = false;
-    RCLCPP_WARN(this->get_logger(), "Disconnected from MG400 at %s", this->ip_address_.c_str());
-    this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(this->mg400_connected_));
-  }
 
   return CallbackReturn::SUCCESS;
 }
@@ -167,20 +174,6 @@ CallbackReturn MG400Node::on_error(const State &)
   this->interface_.reset();
   this->connect_timer_.reset();
   return CallbackReturn::SUCCESS;
-}
-
-void MG400Node::connect()
-{
-  this->connect_timer_.reset();
-
-  if (!this->interface_->activate()) {
-    RCLCPP_WARN(this->get_logger(), "Failed to connect to MG400 at %s", this->ip_address_.c_str());
-    RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
-    this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->connect();});
-    return;
-  }
-
-  this->runTimer();
 }
 
 void MG400Node::onJointStateTimer()
@@ -269,24 +262,8 @@ void MG400Node::onErrorTimer()
 
 void MG400Node::onInterfaceCheckTimer()
 {
-  // when connection is established
-  if (!this->mg400_connected_ && this->interface_->ok()) {
-    this->mg400_connected_ = true;
-    RCLCPP_INFO(this->get_logger(), "Connected to MG400 at %s", this->ip_address_.c_str());
-    this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(this->mg400_connected_));
-  }
-
-  // when connection is lost
-  if (this->mg400_connected_ && !this->interface_->ok()) {
-    this->mg400_connected_ = false;
-    RCLCPP_WARN(this->get_logger(), "Disconnected from MG400 at %s", this->ip_address_.c_str());
-    this->mg400_connected_pub_->publish(std_msgs::msg::Bool().set__data(this->mg400_connected_));
-
-    this->interface_->deactivate();
-    this->cancelTimer();
-
-    RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
-    this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->connect();});
+  if (!this->interface_->ok()) {
+    this->deactivate();
   }
 }
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -95,7 +95,7 @@ CallbackReturn MG400Node::on_configure(const State &)
     "robot_mode", rclcpp::SensorDataQoS());
   this->error_id_pub_ = this->create_publisher<mg400_msgs::msg::ErrorID>(
     "error_id", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().durability_volatile());
-  
+
   this->connection_interrupted_ = false;
 
   if (this->get_parameter("auto_connect").as_bool()) {
@@ -137,7 +137,7 @@ CallbackReturn MG400Node::on_deactivate(const State &)
 
   if (this->connection_interrupted_) {
     RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
-    this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});   
+    this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
   }
 
   return CallbackReturn::SUCCESS;


### PR DESCRIPTION
This PR refactors mg400_node, and use `connection_interrupted_flag` to simplify the reconnection handling (this reconnection feature was introduced in #265 ).