### PR TITLE
Use FD_ISSET along with ::select to avoid ::read() from hanging up

### DIFF
--- a/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
+++ b/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
@@ -136,7 +136,7 @@ bool TcpSocketHandler::recv(void * buf, uint32_t len, const std::chrono::nanosec
     if (err < 0) {
       this->disConnect();
       throw TcpSocketException(this->toString() + std::string(" select() : ") + strerror(errno));
-    } else if (err == 0) {
+    } else if (err == 0 || FD_ISSET(this->fd_, &read_fds) == 0) {
       return false;
     }
     err = static_cast<int>(::read(fd_, tmp, len));


### PR DESCRIPTION
`::select` returns how many file descriptors are available for IO operation, but it doesn't tell the availability of the specific file descriptor. This PR adds `FD_ISSET` along with `::select` to check the availability of the specific file descriptor so the next `::read` will not hang.