### PR TITLE
Support `Speed`, `Acc` and `CP` options of Motion Commands

### DIFF
--- a/mg400_interface/include/mg400_interface/commander/motion_commander.hpp
+++ b/mg400_interface/include/mg400_interface/commander/motion_commander.hpp
@@ -53,39 +53,46 @@ public:
   // DOBOT MG400 Official Command ---------------------------------------------
   void movJ(
     const si_m, const si_m, const si_m,
-    const si_rad, const si_rad = 0.0, const si_rad = 0.0);
+    const si_rad, const si_rad = 0.0, const si_rad = 0.0,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void movL(
     const si_m, const si_m, const si_m,
-    const si_rad, const si_rad = 0.0, const si_rad = 0.0);
+    const si_rad, const si_rad = 0.0, const si_rad = 0.0,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void jointMovJ(
     const si_rad, const si_rad, const si_rad,
-    const si_rad, const si_rad, const si_rad);
+    const si_rad, const si_rad, const si_rad,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void movLIO(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
     const DistanceMode &, const int &,
-    const DOIndex &, const DOStatus &);
+    const DOIndex &, const DOStatus &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
   void movLIO(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
     const DistanceMode::_mode_type &, const int &,
     const DOIndex::_index_type &,
-    const DOStatus::_status_type &);
+    const DOStatus::_status_type &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void movJIO(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
     const DistanceMode &, const int &,
-    const DOIndex &, const DOStatus &);
+    const DOIndex &, const DOStatus &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
   void movJIO(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
     const DistanceMode::_mode_type &, const int &,
     const DOIndex::_index_type &,
-    const DOStatus::_status_type &);
+    const DOStatus::_status_type &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
 /* https://github.com/Dobot-Arm/TCP-IP-CR-Python/issues/4#:~:text=The%20arc%20function%20needs%20to%20be%20fixed%20by%20Dobot
   void arc(
@@ -103,24 +110,29 @@ public:
   void relMovJUser(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
-    const User &);
+    const User &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
   void relMovJUser(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
-    const User::_user_type &);
+    const User::_user_type &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void relMovLUser(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
-    const User &);
+    const User &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
   void relMovLUser(
     const si_m, const si_m, const si_m,
     const si_rad, const si_rad, const si_rad,
-    const User::_user_type &);
+    const User::_user_type &,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void relJointMovJ(
     const si_rad, const si_rad, const si_rad,
-    const si_rad, const si_rad, const si_rad);
+    const si_rad, const si_rad, const si_rad,
+    const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
 
   // End DOBOT MG400 Official Command -----------------------------------------

--- a/mg400_interface/include/mg400_interface/commander/motion_commander.hpp
+++ b/mg400_interface/include/mg400_interface/commander/motion_commander.hpp
@@ -52,43 +52,38 @@ public:
 
   // DOBOT MG400 Official Command ---------------------------------------------
   void movJ(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad = 0.0, const si_rad = 0.0,
+    const si_m, const si_m, const si_m, const si_rad,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void movL(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad = 0.0, const si_rad = 0.0,
+    const si_m, const si_m, const si_m, const si_rad,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void jointMovJ(
-    const si_rad, const si_rad, const si_rad,
-    const si_rad, const si_rad, const si_rad,
+    const si_rad, const si_rad, const si_rad, const si_rad,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void movLIO(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const DistanceMode &, const int &,
     const DOIndex &, const DOStatus &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
+
   void movLIO(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const DistanceMode::_mode_type &, const int &,
     const DOIndex::_index_type &,
     const DOStatus::_status_type &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void movJIO(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const DistanceMode &, const int &,
     const DOIndex &, const DOStatus &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
+
   void movJIO(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const DistanceMode::_mode_type &, const int &,
     const DOIndex::_index_type &,
     const DOStatus::_status_type &,
@@ -108,32 +103,26 @@ public:
   void sync();
 
   void relMovJUser(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const User &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
   void relMovJUser(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const User::_user_type &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void relMovLUser(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const User &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
   void relMovLUser(
-    const si_m, const si_m, const si_m,
-    const si_rad, const si_rad, const si_rad,
+    const si_m, const si_m, const si_m, const si_rad,
     const User::_user_type &,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
 
   void relJointMovJ(
-    const si_rad, const si_rad, const si_rad,
-    const si_rad, const si_rad, const si_rad,
+    const si_rad, const si_rad, const si_rad, const si_rad,
     const int8_t = -1, const int8_t = -1, const int8_t = -1);
-
 
   // End DOBOT MG400 Official Command -----------------------------------------
 };

--- a/mg400_interface/src/commander/motion_commander.cpp
+++ b/mg400_interface/src/commander/motion_commander.cpp
@@ -24,187 +24,160 @@ MotionCommander::MotionCommander(MotionTcpInterfaceBase * tcp_if)
 // DOBOT MG400 Official Command ---------------------------------------------
 void MotionCommander::movJ(
   const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const double r, const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
-  char buf[100];
+  char buf[200];
   snprintf(
     buf, sizeof(buf),
-    "MovJ(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
-    m2mm(x), m2mm(y), m2mm(z),
-    rad2degree(rx), rad2degree(ry), rad2degree(rz));
+    "MovJ(%.3lf,%.3lf,%.3lf,%.3lf",
+    m2mm(x), m2mm(y), m2mm(z), rad2degree(r));
 
-  char temp[50];
   if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedJ=%d", speed_j);
   }
   if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccJ=%d", acc_j);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ")");
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::movL(
   const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_rad r, const int8_t speed_l, const int8_t acc_l, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "MovL(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
-    m2mm(x), m2mm(y), m2mm(z),
-    rad2degree(rx), rad2degree(ry), rad2degree(rz));
+    "MovL(%.3lf,%.3lf,%.3lf,%.3lf",
+    m2mm(x), m2mm(y), m2mm(z), rad2degree(r));
 
-  char temp[50];
-  if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  if (speed_l >= 0) {
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedL=%d", speed_l);
   }
-  if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  if (acc_l >= 0) {
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccL=%d", acc_l);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::jointMovJ(
-  const si_rad j1, const si_rad j2, const si_rad j3,
-  const si_rad j4, const si_rad j5, const si_rad j6,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_rad j1, const si_rad j2, const si_rad j3, const si_rad j4,
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "JointMovJ(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
-    rad2degree(j1), rad2degree(j2), rad2degree(j3),
-    rad2degree(j4), rad2degree(j5), rad2degree(j6));
+    "JointMovJ(%.3lf,%.3lf,%.3lf,%.3lf",
+    rad2degree(j1), rad2degree(j2), rad2degree(j3), rad2degree(j4));
 
-  char temp[50];
   if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedJ=%d", speed_j);
   }
   if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccJ=%d", acc_j);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::movLIO(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
+  const si_m x, const si_m y, const si_m z, const si_rad r,
   const DistanceMode & mode, const int & distance,
   const DOIndex & index, const DOStatus & status,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const int8_t speed_l, const int8_t acc_l, const int8_t cp)
 {
   this->movLIO(
-    x, y, z, rx, ry, rz,
+    x, y, z, r,
     mode.mode, distance,
     index.index, status.status,
-    speed_j, acc_j, cp);
+    speed_l, acc_l, cp);
 }
 
 void MotionCommander::movLIO(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
+  const si_m x, const si_m y, const si_m z, const si_rad r,
   const DistanceMode::_mode_type & mode,
   const int & distance,
   const DOIndex::_index_type & index,
   const DOStatus::_status_type & status,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const int8_t speed_l, const int8_t acc_l, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "MovLIO(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,{%u,%d,%u,%u})",
-    m2mm(x), m2mm(y), m2mm(z),
-    rad2degree(rx), rad2degree(ry), rad2degree(rz),
+    "MovLIO(%.3lf,%.3lf,%.3lf,%.3lf,{%u,%d,%u,%u}",
+    m2mm(x), m2mm(y), m2mm(z), rad2degree(r),
     mode, distance, index, status);
 
-  char temp[50];
-  if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  if (speed_l >= 0) {
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedL=%d", speed_l);
   }
-  if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  if (acc_l >= 0) {
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccL=%d", acc_l);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::movJIO(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
+  const si_m x, const si_m y, const si_m z, const si_rad r,
   const DistanceMode & mode, const int & distance,
   const DOIndex & index, const DOStatus & status,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   this->movJIO(
-    x, y, z, rx, ry, rz,
+    x, y, z, r,
     mode.mode, distance, index.index, status.status,
     speed_j, acc_j, cp);
 }
 
 void MotionCommander::movJIO(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
+  const si_m x, const si_m y, const si_m z, const si_rad r,
   const DistanceMode::_mode_type & mode, const int & distance,
   const DOIndex::_index_type & index,
   const DOStatus::_status_type & status,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "MovJIO(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,{%u,%d,%u,%u})",
-    m2mm(x), m2mm(y), m2mm(z),
-    rad2degree(rx), rad2degree(ry), rad2degree(rz),
+    "MovJIO(%.3lf,%.3lf,%.3lf,%.3lf,{%u,%d,%u,%u}",
+    m2mm(x), m2mm(y), m2mm(z), rad2degree(r),
     mode, distance, index, status);
 
-  char temp[50];
   if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedJ=%d", speed_j);
   }
   if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccJ=%d", acc_j);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 
@@ -251,118 +224,96 @@ void MotionCommander::sync()
 }
 
 void MotionCommander::relMovJUser(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
-  const User & user,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_m x, const si_m y, const si_m z, const si_rad r, const User & user,
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   this->relMovJUser(
-    x, y, z, rx, ry, rz,
-    user.user,
+    x, y, z, r, user.user,
     speed_j, acc_j, cp);
 }
 
 void MotionCommander::relMovJUser(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
-  const User::_user_type & user,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_m x, const si_m y, const si_m z, const si_rad r, const User::_user_type & user,
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "RelMovJUser(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%u)",
-    m2mm(x), m2mm(y), m2mm(z),
-    rad2degree(rx), rad2degree(ry), rad2degree(rz), user);
+    "RelMovJUser(%.3lf,%.3lf,%.3lf,%.3lf,%u",
+    m2mm(x), m2mm(y), m2mm(z), rad2degree(r), user);
 
-  char temp[50];
   if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedJ=%d", speed_j);
   }
   if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccJ=%d", acc_j);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::relMovLUser(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
-  const User & user,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_m x, const si_m y, const si_m z, const si_rad r, const User & user,
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   this->relMovLUser(
-    x, y, z, rx, ry, rz,
+    x, y, z, r,
     user.user,
     speed_j, acc_j, cp);
 }
 
 void MotionCommander::relMovLUser(
-  const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz,
-  const User::_user_type & user,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_m x, const si_m y, const si_m z, const si_rad r, const User::_user_type & user,
+  const int8_t speed_l, const int8_t acc_l, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "RelMovLUser(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%u)",
-    m2mm(x), m2mm(y), m2mm(z),
-    rad2degree(rx), rad2degree(ry), rad2degree(rz), user);
+    "RelMovLUser(%.3lf,%.3lf,%.3lf,%.3lf,%u",
+    m2mm(x), m2mm(y), m2mm(z), rad2degree(r), user);
 
-  char temp[50];
-  if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  if (speed_l >= 0) {
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedL=%d", speed_l);
   }
-  if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  if (acc_l >= 0) {
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccL=%d", acc_l);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::relJointMovJ(
-  const si_rad j1, const si_rad j2, const si_rad j3,
-  const si_rad j4, const si_rad j5, const si_rad j6,
-  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
+  const si_rad j1, const si_rad j2, const si_rad j3, const si_rad j4,
+  const int8_t speed_j, const int8_t acc_j, const int8_t cp)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
   snprintf(
     buf, sizeof(buf),
-    "RelJointMovJ(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
-    rad2degree(j1), rad2degree(j2), rad2degree(j3),
-    rad2degree(j4), rad2degree(j5), rad2degree(j6));
+    "RelJointMovJ(%.3lf,%.3lf,%.3lf,%.3lf",
+    rad2degree(j1), rad2degree(j2), rad2degree(j3), rad2degree(j4));
 
-  char temp[50];
   if (speed_j >= 0) {
-    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",SpeedJ=%d", speed_j);
   }
   if (acc_j >= 0) {
-    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",AccJ=%d", acc_j);
   }
   if (cp >= 0) {
-    snprintf(temp, sizeof(temp), " CP=%d", cp);
-    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+    snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), ",CP=%d", cp);
   }
 
+  strncat(buf, ")", sizeof(buf) - strlen(buf) - 1);
   this->tcp_if_->sendCommand(buf);
 }
 

--- a/mg400_interface/src/commander/motion_commander.cpp
+++ b/mg400_interface/src/commander/motion_commander.cpp
@@ -24,7 +24,8 @@ MotionCommander::MotionCommander(MotionTcpInterfaceBase * tcp_if)
 // DOBOT MG400 Official Command ---------------------------------------------
 void MotionCommander::movJ(
   const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz)
+  const si_rad rx, const si_rad ry, const si_rad rz,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -33,12 +34,28 @@ void MotionCommander::movJ(
     "MovJ(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
     m2mm(x), m2mm(y), m2mm(z),
     rad2degree(rx), rad2degree(ry), rad2degree(rz));
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::movL(
   const si_m x, const si_m y, const si_m z,
-  const si_rad rx, const si_rad ry, const si_rad rz)
+  const si_rad rx, const si_rad ry, const si_rad rz,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -47,12 +64,28 @@ void MotionCommander::movL(
     "MovL(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
     m2mm(x), m2mm(y), m2mm(z),
     rad2degree(rx), rad2degree(ry), rad2degree(rz));
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::jointMovJ(
   const si_rad j1, const si_rad j2, const si_rad j3,
-  const si_rad j4, const si_rad j5, const si_rad j6)
+  const si_rad j4, const si_rad j5, const si_rad j6,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -61,6 +94,21 @@ void MotionCommander::jointMovJ(
     "JointMovJ(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
     rad2degree(j1), rad2degree(j2), rad2degree(j3),
     rad2degree(j4), rad2degree(j5), rad2degree(j6));
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
@@ -68,12 +116,14 @@ void MotionCommander::movLIO(
   const si_m x, const si_m y, const si_m z,
   const si_rad rx, const si_rad ry, const si_rad rz,
   const DistanceMode & mode, const int & distance,
-  const DOIndex & index, const DOStatus & status)
+  const DOIndex & index, const DOStatus & status,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   this->movLIO(
     x, y, z, rx, ry, rz,
     mode.mode, distance,
-    index.index, status.status);
+    index.index, status.status,
+    speed_j, acc_j, cp);
 }
 
 void MotionCommander::movLIO(
@@ -82,7 +132,8 @@ void MotionCommander::movLIO(
   const DistanceMode::_mode_type & mode,
   const int & distance,
   const DOIndex::_index_type & index,
-  const DOStatus::_status_type & status)
+  const DOStatus::_status_type & status,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -92,6 +143,21 @@ void MotionCommander::movLIO(
     m2mm(x), m2mm(y), m2mm(z),
     rad2degree(rx), rad2degree(ry), rad2degree(rz),
     mode, distance, index, status);
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
@@ -99,11 +165,13 @@ void MotionCommander::movJIO(
   const si_m x, const si_m y, const si_m z,
   const si_rad rx, const si_rad ry, const si_rad rz,
   const DistanceMode & mode, const int & distance,
-  const DOIndex & index, const DOStatus & status)
+  const DOIndex & index, const DOStatus & status,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   this->movJIO(
     x, y, z, rx, ry, rz,
-    mode.mode, distance, index.index, status.status);
+    mode.mode, distance, index.index, status.status,
+    speed_j, acc_j, cp);
 }
 
 void MotionCommander::movJIO(
@@ -111,7 +179,8 @@ void MotionCommander::movJIO(
   const si_rad rx, const si_rad ry, const si_rad rz,
   const DistanceMode::_mode_type & mode, const int & distance,
   const DOIndex::_index_type & index,
-  const DOStatus::_status_type & status)
+  const DOStatus::_status_type & status,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -121,6 +190,21 @@ void MotionCommander::movJIO(
     m2mm(x), m2mm(y), m2mm(z),
     rad2degree(rx), rad2degree(ry), rad2degree(rz),
     mode, distance, index, status);
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
@@ -169,17 +253,20 @@ void MotionCommander::sync()
 void MotionCommander::relMovJUser(
   const si_m x, const si_m y, const si_m z,
   const si_rad rx, const si_rad ry, const si_rad rz,
-  const User & user)
+  const User & user,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   this->relMovJUser(
     x, y, z, rx, ry, rz,
-    user.user);
+    user.user,
+    speed_j, acc_j, cp);
 }
 
 void MotionCommander::relMovJUser(
   const si_m x, const si_m y, const si_m z,
   const si_rad rx, const si_rad ry, const si_rad rz,
-  const User::_user_type & user)
+  const User::_user_type & user,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -188,23 +275,41 @@ void MotionCommander::relMovJUser(
     "RelMovJUser(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%u)",
     m2mm(x), m2mm(y), m2mm(z),
     rad2degree(rx), rad2degree(ry), rad2degree(rz), user);
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::relMovLUser(
   const si_m x, const si_m y, const si_m z,
   const si_rad rx, const si_rad ry, const si_rad rz,
-  const User & user)
+  const User & user,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   this->relMovLUser(
     x, y, z, rx, ry, rz,
-    user.user);
+    user.user,
+    speed_j, acc_j, cp);
 }
 
 void MotionCommander::relMovLUser(
   const si_m x, const si_m y, const si_m z,
   const si_rad rx, const si_rad ry, const si_rad rz,
-  const User::_user_type & user)
+  const User::_user_type & user,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -213,12 +318,28 @@ void MotionCommander::relMovLUser(
     "RelMovLUser(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%u)",
     m2mm(x), m2mm(y), m2mm(z),
     rad2degree(rx), rad2degree(ry), rad2degree(rz), user);
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 
 void MotionCommander::relJointMovJ(
   const si_rad j1, const si_rad j2, const si_rad j3,
-  const si_rad j4, const si_rad j5, const si_rad j6)
+  const si_rad j4, const si_rad j5, const si_rad j6,
+  const int8_t speed_j = -1, const int8_t acc_j = -1, const int8_t cp = -1)
 {
   std::lock_guard<std::mutex> lock_tcp_if_(this->mutex_tcp_if_);
   char buf[100];
@@ -227,6 +348,21 @@ void MotionCommander::relJointMovJ(
     "RelJointMovJ(%.3lf,%.3lf,%.3lf,%.3lf,%.3lf,%.3lf)",
     rad2degree(j1), rad2degree(j2), rad2degree(j3),
     rad2degree(j4), rad2degree(j5), rad2degree(j6));
+
+  char temp[50];
+  if (speed_j >= 0) {
+    snprintf(temp, sizeof(temp), " SpeedJ=%d", speed_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (acc_j >= 0) {
+    snprintf(temp, sizeof(temp), " AccJ=%d", acc_j);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+  if (cp >= 0) {
+    snprintf(temp, sizeof(temp), " CP=%d", cp);
+    strncat(buf, temp, sizeof(buf) - strlen(buf) - 1);
+  }
+
   this->tcp_if_->sendCommand(buf);
 }
 

--- a/mg400_interface/test/src/commander/test_motion_commander.cpp
+++ b/mg400_interface/test/src/commander/test_motion_commander.cpp
@@ -51,49 +51,94 @@ TEST_F(TestMotionCommander, MovJ) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "MovJ(1.000,2.000,3.000,180.000,180.000,180.000)"))).Times(1);
-  commander->movJ(1.0e-3, 2.0e-3, 3.0e-3, M_PI, M_PI, M_PI);
+        "MovJ(1.000,2.000,3.000,180.000)"))).Times(1);
+  commander->movJ(1.0e-3, 2.0e-3, 3.0e-3, M_PI);
+}
+
+TEST_F(TestMotionCommander, MovJ2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "MovJ(1.000,2.000,3.000,180.000,SpeedJ=100,AccJ=50,CP=10)"))).Times(1);
+  commander->movJ(1.0e-3, 2.0e-3, 3.0e-3, M_PI, 100, 50, 10);
 }
 
 TEST_F(TestMotionCommander, MovL) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "MovL(1.000,2.000,3.000,180.000,180.000,180.000)"))).Times(1);
-  commander->movL(1.0e-3, 2.0e-3, 3.0e-3, M_PI, M_PI, M_PI);
+        "MovL(1.000,2.000,3.000,180.000)"))).Times(1);
+  commander->movL(1.0e-3, 2.0e-3, 3.0e-3, M_PI);
 }
 
+TEST_F(TestMotionCommander, MovL2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "MovL(1.000,2.000,3.000,180.000,SpeedL=100,AccL=50,CP=10)"))).Times(1);
+  commander->movL(1.0e-3, 2.0e-3, 3.0e-3, M_PI, 100, 50, 10);
+}
 
 TEST_F(TestMotionCommander, JointMovJ)
 {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "JointMovJ(90.000,90.000,90.000,90.000,90.000,90.000)"))).Times(1);
-  commander->jointMovJ(M_PI_2, M_PI_2, M_PI_2, M_PI_2, M_PI_2, M_PI_2);
+        "JointMovJ(90.000,90.000,90.000,90.000)"))).Times(1);
+  commander->jointMovJ(M_PI_2, M_PI_2, M_PI_2, M_PI_2);
+}
+
+TEST_F(TestMotionCommander, JointMovJ2)
+{
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "JointMovJ(90.000,90.000,90.000,90.000,SpeedJ=100,AccJ=50,CP=10)"))).Times(1);
+  commander->jointMovJ(M_PI_2, M_PI_2, M_PI_2, M_PI_2, 100, 50, 10);
 }
 
 TEST_F(TestMotionCommander, MovLIO) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "MovLIO(-500.000,100.000,200.000,"
-        "90.000,0.000,90.000,{0,50,1,0})"))).Times(1);
+        "MovLIO(-500.000,100.000,200.000,90.000,{0,50,1,0})"))).Times(1);
   commander->movLIO(
-    -500e-3, 100e-3, 200e-3, M_PI_2, 0, M_PI_2,
+    -500e-3, 100e-3, 200e-3, M_PI_2,
     DistanceMode::PERCENTAGE, 50, DOIndex::D1, DOStatus::LOW);
+}
+
+TEST_F(TestMotionCommander, MovLIO2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "MovLIO(-500.000,100.000,200.000,90.000,{0,50,1,0},SpeedL=100,AccL=50,CP=10)"))).Times(1);
+  commander->movLIO(
+    -500e-3, 100e-3, 200e-3, M_PI_2,
+    DistanceMode::PERCENTAGE, 50, DOIndex::D1, DOStatus::LOW,
+    100, 50, 10);
 }
 
 TEST_F(TestMotionCommander, MovJIO) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "MovJIO(-500.000,100.000,200.000,"
-        "90.000,0.000,90.000,{0,50,1,0})"))).Times(1);
+        "MovJIO(-500.000,100.000,200.000,90.000,{0,50,1,0})"))).Times(1);
   commander->movJIO(
-    -500e-3, 100e-3, 200e-3, M_PI_2, 0, M_PI_2,
+    -500e-3, 100e-3, 200e-3, M_PI_2,
     DistanceMode::PERCENTAGE, 50, DOIndex::D1, DOStatus::LOW);
 }
+
+TEST_F(TestMotionCommander, MovJIO2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "MovJIO(-500.000,100.000,200.000,90.000,{0,50,1,0},SpeedJ=100,AccJ=50,CP=10)"))).Times(1);
+  commander->movJIO(
+    -500e-3, 100e-3, 200e-3, M_PI_2,
+    DistanceMode::PERCENTAGE, 50, DOIndex::D1, DOStatus::LOW,
+    100, 50, 10);
+}
+
 /*
 TEST_F(TestMotionCommander, Arc) {
   EXPECT_CALL(
@@ -132,31 +177,52 @@ TEST_F(TestMotionCommander, RelMovJUser) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "RelMovJUser(10.000,10.000,10.000,"
-        "0.000,0.000,0.000,0)"))).Times(1);
+        "RelMovJUser(10.000,10.000,10.000,0.000,0)"))).Times(1);
   commander->relMovJUser(
-    10e-3, 10e-3, 10e-3, 0, 0, 0,
-    User::USER0);
+    10e-3, 10e-3, 10e-3, 0, User::USER0);
+}
+
+TEST_F(TestMotionCommander, RelMovJUser2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "RelMovJUser(10.000,10.000,10.000,0.000,0,SpeedJ=100,AccJ=50,CP=10)"))).Times(1);
+  commander->relMovJUser(
+    10e-3, 10e-3, 10e-3, 0, User::USER0, 100, 50, 10);
 }
 
 TEST_F(TestMotionCommander, RelMovLUser) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "RelMovLUser(10.000,10.000,10.000,"
-        "0.000,0.000,0.000,0)"))).Times(1);
+        "RelMovLUser(10.000,10.000,10.000,0.000,0)"))).Times(1);
   commander->relMovLUser(
-    10e-3, 10e-3, 10e-3, 0, 0, 0,
-    User::USER0);
+    10e-3, 10e-3, 10e-3, 0, User::USER0);
+}
+
+TEST_F(TestMotionCommander, RelMovLUser2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "RelMovLUser(10.000,10.000,10.000,0.000,0,SpeedL=100,AccL=50,CP=10)"))).Times(1);
+  commander->relMovLUser(
+    10e-3, 10e-3, 10e-3, 0, User::USER0, 100, 50, 10);
 }
 
 TEST_F(TestMotionCommander, RelJointMovJ) {
   EXPECT_CALL(
     mock, sendCommand(
       StrEq(
-        "RelJointMovJ(90.000,90.000,90.000,"
-        "0.000,0.000,0.000)"))).Times(1);
+        "RelJointMovJ(90.000,90.000,90.000,0.000)"))).Times(1);
   commander->relJointMovJ(
-    M_PI_2, M_PI_2, M_PI_2,
-    0, 0, 0);
+    M_PI_2, M_PI_2, M_PI_2, 0);
+}
+
+TEST_F(TestMotionCommander, RelJointMovJ2) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq(
+        "RelJointMovJ(90.000,90.000,90.000,0.000,SpeedJ=100,AccJ=50,CP=10)"))).Times(1);
+  commander->relJointMovJ(
+    M_PI_2, M_PI_2, M_PI_2, 0, 100, 50, 10);
 }

--- a/mg400_msgs/action/MovJ.action
+++ b/mg400_msgs/action/MovJ.action
@@ -1,5 +1,11 @@
 #goal definition
 geometry_msgs/PoseStamped pose
+bool set_speed_j
+uint8 speed_j
+bool set_acc_j
+uint8 acc_j
+bool set_cp
+uint8 cp
 ---
 #result definition
 bool result

--- a/mg400_msgs/action/MovL.action
+++ b/mg400_msgs/action/MovL.action
@@ -1,5 +1,11 @@
 #goal definition
 geometry_msgs/PoseStamped pose
+bool set_speed_l
+uint8 speed_l
+bool set_acc_l
+uint8 acc_l
+bool set_cp
+uint8 cp
 ---
 #result definition
 bool result

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -136,10 +136,23 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
 
   // send MovJ command
   try {
+    int8_t speed_j = -1;
+    int8_t acc_j = -1;
+    int8_t cp = -1;
+    if (goal->set_speed_j) {
+      speed_j = goal->speed_j;
+    }
+    if (goal->set_acc_j) {
+      acc_j = goal->acc_j;
+    }
+    if (goal->set_cp) {
+      cp = goal->cp;
+    }
     this->commander_->movJ(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,
       this->tf_goal_.pose.position.z,
-      tf2::getYaw(this->tf_goal_.pose.orientation));
+      tf2::getYaw(this->tf_goal_.pose.orientation),
+      speed_j, acc_j, cp);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(
       this->node_logging_if_->get_logger(), e.what());

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -136,10 +136,23 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
 
   // send MovL command
   try {
+    int8_t speed_l = -1;
+    int8_t acc_l = -1;
+    int8_t cp = -1;
+    if (goal->set_speed_l) {
+      speed_l = goal->speed_l;
+    }
+    if (goal->set_acc_l) {
+      acc_l = goal->acc_l;
+    }
+    if (goal->set_cp) {
+      cp = goal->cp;
+    }
     this->commander_->movL(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,
       this->tf_goal_.pose.position.z,
-      tf2::getYaw(this->tf_goal_.pose.orientation));
+      tf2::getYaw(this->tf_goal_.pose.orientation),
+      speed_l, acc_l, cp);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(
       this->node_logging_if_->get_logger(), e.what());


### PR DESCRIPTION
The latest mg400 tcp ip interface supports additional parameters `SpeedJ`, `SpeedL`, `AccJ`, `AccL`, `CP` options for `MovJ`, `MovL` etc. To support them, this PR updates motion commander and ros2 action definition.