### PR TITLE
Stop trying to reconnect when `auto_connect` is false

### DIFF
--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -135,7 +135,7 @@ CallbackReturn MG400Node::on_deactivate(const State &)
   this->cancelTimer();
   this->interface_->deactivate();
 
-  if (this->connection_interrupted_) {
+  if (this->get_parameter("auto_connect").as_bool() || this->connection_interrupted_) {
     RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
     this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
   }

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -112,7 +112,7 @@ CallbackReturn MG400Node::on_activate(const State &)
 
   if (!this->interface_->activate()) {
     RCLCPP_WARN(this->get_logger(), "Failed to connect to MG400 at %s", this->ip_address_.c_str());
-    if (this->get_parameter("auto_connect").as_bool() || this->connection_interrupted_) {
+    if (this->get_parameter("auto_connect").as_bool() && this->connection_interrupted_) {
       RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
       this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
     }
@@ -135,7 +135,7 @@ CallbackReturn MG400Node::on_deactivate(const State &)
   this->cancelTimer();
   this->interface_->deactivate();
 
-  if (this->get_parameter("auto_connect").as_bool() || this->connection_interrupted_) {
+  if (this->get_parameter("auto_connect").as_bool() && this->connection_interrupted_) {
     RCLCPP_INFO(this->get_logger(), "Try reconnecting in 5 seconds ...");
     this->connect_timer_ = this->create_wall_timer(5s, [this]() {this->activate();});
   }


### PR DESCRIPTION
Current impelmentation tries to reconnect to MG400 when it was interrupted, but when `auto_connect` option is not enabled, this behavior is somewhat unexpected. So this PR fixes it.