### PR TITLE
Fix/add value validation

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,10 +6,6 @@
         "limitSymbolsToIncludedHeaders": false
       },
       "includePath": [
-        "/usr/include/**",
-        "/opt/ros/humble/include/**",
-        "/opt/ros/humble/src/gmock_vendor/include/**",
-        "/opt/ros/humble/opt/rviz_ogre_vendor/include/**",
         "${workspaceFolder}/mg400_common/include/**",
         "${workspaceFolder}/mg400_interface/include/**",
         "${workspaceFolder}/mg400_joy/include/**",
@@ -18,7 +14,11 @@
         "${workspaceFolder}/mg400_node/src/joint_state_publisher/**",
         "${workspaceFolder}/mg400_plugin_base/include/**",
         "${workspaceFolder}/mg400_plugin/include/**",
-        "${workspaceFolder}/mg400_rviz_plugin/include/**"
+        "${workspaceFolder}/mg400_rviz_plugin/include/**",
+        "/usr/include/**",
+        "/opt/ros/humble/include/**",
+        "/opt/ros/humble/src/gmock_vendor/include/**",
+        "/opt/ros/humble/opt/rviz_ogre_vendor/include/**"
       ],
       "name": "ROS",
       "intelliSenseMode": "clang-x64",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -98,6 +98,22 @@
     "typeindex": "cpp",
     "typeinfo": "cpp",
     "valarray": "cpp",
-    "variant": "cpp"
+    "variant": "cpp",
+    "csetjmp": "cpp",
+    "*.ipp": "cpp",
+    "barrier": "cpp",
+    "charconv": "cpp",
+    "coroutine": "cpp",
+    "cuchar": "cpp",
+    "netfwd": "cpp",
+    "source_location": "cpp",
+    "rope": "cpp",
+    "slist": "cpp",
+    "latch": "cpp",
+    "ranges": "cpp",
+    "scoped_allocator": "cpp",
+    "span": "cpp",
+    "syncstream": "cpp"
   },
+  "C_Cpp.errorSquiggles": "disabled",
 }

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/acc_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/acc_j.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_ACC_J_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/acc_j.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/acc_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/acc_l.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_ACC_L_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/acc_l.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/cp.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/cp.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_CP_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/cp.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_factor.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_factor.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_SPEED_FACTOR_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/speed_factor.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_j.hpp
@@ -16,7 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_SPEED_J_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
-#include <mg401_plugin/plugin_utils.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/speed_j.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_j.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_SPEED_J_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg401_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/speed_j.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/speed_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/speed_l.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_DASHBOARD_API_SPEED_L_HPP__
 
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <mg400_msgs/srv/speed_l.hpp>
 
 namespace mg400_plugin

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
@@ -21,6 +21,7 @@
 #include <mg400_msgs/action/mov_j.hpp>
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_jio.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_jio.hpp
@@ -21,6 +21,7 @@
 #include <mg400_msgs/action/mov_jio.hpp>
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_l.hpp
@@ -21,6 +21,7 @@
 #include <mg400_msgs/action/mov_l.hpp>
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_lio.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_lio.hpp
@@ -21,6 +21,7 @@
 #include <mg400_msgs/action/mov_lio.hpp>
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_plugin/plugin_utils.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>

--- a/mg400_plugin/include/mg400_plugin/plugin_utils.hpp
+++ b/mg400_plugin/include/mg400_plugin/plugin_utils.hpp
@@ -16,6 +16,7 @@
 #define __MG400_PLUGIN_PLUGIN_UTILS_HPP__
 
 #include <string>
+#include <rclcpp/rclcpp.hpp>
 
 namespace mg400_plugin
 {
@@ -33,13 +34,18 @@ const uint8_t CP_MIN = 0, CP_MAX = 100;
 
 
 template<typename T>
-inline T clampWithWarning(T value, T min, T max, const std::string & name)
+inline T clampWithWarning(
+  T value, T min, T max, const rclcpp::Logger & logger, const std::string & arg_name)
 {
   if (value < min) {
-    std::cerr << "[Warning] " << name << " clamped from " << +value << " to " << +min << std::endl;
+    RCLCPP_WARN(
+      logger, "%s clamped from %d to %d",
+      arg_name.c_str(), static_cast<int>(value), static_cast<int>(min));
     return min;
   } else if (value > max) {
-    std::cerr << "[Warning] " << name << " clamped from " << +value << " to " << +max << std::endl;
+    RCLCPP_WARN(
+      logger, "%s clamped from %d to %d",
+      arg_name.c_str(), static_cast<int>(value), static_cast<int>(max));
     return max;
   }
   return value;

--- a/mg400_plugin/include/mg400_plugin/plugin_utils.hpp
+++ b/mg400_plugin/include/mg400_plugin/plugin_utils.hpp
@@ -1,0 +1,52 @@
+/// Copyright 2025 HarvestX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __MG400_PLUGIN_PLUGIN_UTILS_HPP__
+#define __MG400_PLUGIN_PLUGIN_UTILS_HPP__
+
+#include <string>
+
+namespace mg400_plugin
+{
+
+namespace plugin_utils
+{
+
+
+const uint8_t SPEED_FACTOR_MIN = 1, SPEED_FACTOR_MAX = 100;
+const uint8_t SPEED_J_MIN = 1, SPEED_J_MAX = 100;
+const uint8_t SPEED_L_MIN = 1, SPEED_L_MAX = 100;
+const uint8_t ACC_J_MIN = 1, ACC_J_MAX = 100;
+const uint8_t ACC_L_MIN = 1, ACC_L_MAX = 100;
+const uint8_t CP_MIN = 0, CP_MAX = 100;
+
+
+template<typename T>
+inline T clampWithWarning(T value, T min, T max, const std::string & name)
+{
+  if (value < min) {
+    std::cerr << "[Warning] " << name << " clamped from " << +value << " to " << +min << std::endl;
+    return min;
+  } else if (value > max) {
+    std::cerr << "[Warning] " << name << " clamped from " << +value << " to " << +max << std::endl;
+    return max;
+  }
+  return value;
+}
+
+}  // namespace plugin_utils
+
+}  // namespace mg400_plugin
+
+#endif  // __MG400_PLUGIN_PLUGIN_UTILS_HPP__

--- a/mg400_plugin/src/dashboard_api/acc_j.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_j.cpp
@@ -53,7 +53,8 @@ void AccJ::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t r = plugin_utils::clampWithWarning(
-        req->r, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX, "acc_j");
+        req->r, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX,
+        this->node_logging_if_->get_logger(), "acc_j");
       this->commander_->accJ(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/dashboard_api/acc_j.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_j.cpp
@@ -52,7 +52,9 @@ void AccJ::onServiceCall(
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->accJ(static_cast<int>(req->r));
+      uint8_t r = plugin_utils::clampWithWarning(
+        req->r, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX, "acc_j");
+      this->commander_->accJ(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {

--- a/mg400_plugin/src/dashboard_api/acc_l.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_l.cpp
@@ -53,7 +53,8 @@ void AccL::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t r = plugin_utils::clampWithWarning(
-        req->r, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX, "acc_l");
+        req->r, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX,
+        this->node_logging_if_->get_logger(), "acc_l");
       this->commander_->accL(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/dashboard_api/acc_l.cpp
+++ b/mg400_plugin/src/dashboard_api/acc_l.cpp
@@ -52,7 +52,9 @@ void AccL::onServiceCall(
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->accL(static_cast<int>(req->r));
+      uint8_t r = plugin_utils::clampWithWarning(
+        req->r, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX, "acc_l");
+      this->commander_->accL(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -52,7 +52,8 @@ void CP::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t r = plugin_utils::clampWithWarning(
-        static_cast<uint8_t>(req->r), plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+        static_cast<uint8_t>(req->r), plugin_utils::CP_MIN, plugin_utils::CP_MAX,
+        this->node_logging_if_->get_logger(), "cp");
       this->commander_->cp(r);
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -52,7 +52,7 @@ void CP::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t r = plugin_utils::clampWithWarning(
-        req->r, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+        static_cast<uint8_t>(req->r), plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
       this->commander_->cp(r);
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/dashboard_api/cp.cpp
+++ b/mg400_plugin/src/dashboard_api/cp.cpp
@@ -51,7 +51,9 @@ void CP::onServiceCall(
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->cp(req->r);
+      uint8_t r = plugin_utils::clampWithWarning(
+        req->r, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+      this->commander_->cp(r);
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {

--- a/mg400_plugin/src/dashboard_api/speed_factor.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_factor.cpp
@@ -51,7 +51,8 @@ void SpeedFactor::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t ratio = plugin_utils::clampWithWarning(
-        req->ratio, plugin_utils::SPEED_FACTOR_MIN, plugin_utils::SPEED_FACTOR_MAX, "speed_factor");
+        req->ratio, plugin_utils::SPEED_FACTOR_MIN, plugin_utils::SPEED_FACTOR_MAX,
+        this->node_logging_if_->get_logger(), "speed_factor");
       this->commander_->speedFactor(static_cast<int>(ratio));
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/dashboard_api/speed_factor.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_factor.cpp
@@ -50,7 +50,9 @@ void SpeedFactor::onServiceCall(
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->speedFactor(static_cast<int>(req->ratio));
+      uint8_t ratio = plugin_utils::clampWithWarning(
+        req->ratio, plugin_utils::SPEED_FACTOR_MIN, plugin_utils::SPEED_FACTOR_MAX, "speed_factor");
+      this->commander_->speedFactor(static_cast<int>(ratio));
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {

--- a/mg400_plugin/src/dashboard_api/speed_j.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_j.cpp
@@ -53,7 +53,8 @@ void SpeedJ::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t r = plugin_utils::clampWithWarning(
-        req->r, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX, "speed_j");
+        req->r, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX,
+        this->node_logging_if_->get_logger(), "speed_j");
       this->commander_->speedJ(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/dashboard_api/speed_j.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_j.cpp
@@ -52,7 +52,9 @@ void SpeedJ::onServiceCall(
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->speedJ(static_cast<int>(req->r));
+      uint8_t r = plugin_utils::clampWithWarning(
+        req->r, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX, "speed_j");
+      this->commander_->speedJ(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {

--- a/mg400_plugin/src/dashboard_api/speed_l.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_l.cpp
@@ -52,7 +52,9 @@ void SpeedL::onServiceCall(
   res->error_id = -1;
   if (this->mg400_interface_->ok()) {
     try {
-      this->commander_->speedL(static_cast<int>(req->r));
+      uint8_t r = plugin_utils::clampWithWarning(
+        req->r, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX, "speed_l");
+      this->commander_->speedL(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;
     } catch (const mg400_interface::DashboardCommandException & ex) {

--- a/mg400_plugin/src/dashboard_api/speed_l.cpp
+++ b/mg400_plugin/src/dashboard_api/speed_l.cpp
@@ -53,7 +53,8 @@ void SpeedL::onServiceCall(
   if (this->mg400_interface_->ok()) {
     try {
       uint8_t r = plugin_utils::clampWithWarning(
-        req->r, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX, "speed_l");
+        req->r, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX,
+        this->node_logging_if_->get_logger(), "speed_l");
       this->commander_->speedL(static_cast<int>(r));
       res->result = true;
       res->error_id = 0;

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -142,15 +142,18 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t cp = -1;
     if (goal->set_speed_j) {
       speed_j = plugin_utils::clampWithWarning(
-        goal->speed_j, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX, "speed_j");
+        goal->speed_j, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX,
+        this->node_logging_if_->get_logger(), "speed_j");
     }
     if (goal->set_acc_j) {
       acc_j = plugin_utils::clampWithWarning(
-        goal->acc_j, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX, "acc_j");
+        goal->acc_j, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX,
+        this->node_logging_if_->get_logger(), "acc_j");
     }
     if (goal->set_cp) {
       cp = plugin_utils::clampWithWarning(
-        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX,
+        this->node_logging_if_->get_logger(), "cp");
     }
     this->commander_->movJ(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -123,7 +123,8 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
   try {
     angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
     RCLCPP_INFO(
-      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
+      this->node_logging_if_->get_logger(),
+      "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
       angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
@@ -140,13 +141,16 @@ void MovJ::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t acc_j = -1;
     int8_t cp = -1;
     if (goal->set_speed_j) {
-      speed_j = goal->speed_j;
+      speed_j = plugin_utils::clampWithWarning(
+        goal->speed_j, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX, "speed_j");
     }
     if (goal->set_acc_j) {
-      acc_j = goal->acc_j;
+      acc_j = plugin_utils::clampWithWarning(
+        goal->acc_j, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX, "acc_j");
     }
     if (goal->set_cp) {
-      cp = goal->cp;
+      cp = plugin_utils::clampWithWarning(
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
     }
     this->commander_->movJ(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_jio.cpp
+++ b/mg400_plugin/src/motion_api/mov_jio.cpp
@@ -123,8 +123,9 @@ void MovJIO::execute(const std::shared_ptr<GoalHandle> goal_handle)
   try {
     angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
     RCLCPP_INFO(
-      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
-      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
+      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}",
+      angles[0] * 180.0 / M_PI, angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI,
+      angles[3] * 180.0 / M_PI);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
     // ErrorID 18: Inverse kinematics error with result out of working area
@@ -140,13 +141,16 @@ void MovJIO::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t acc_j = -1;
     int8_t cp = -1;
     if (goal->set_speed_j) {
-      speed_j = goal->speed_j;
+      speed_j = plugin_utils::clampWithWarning(
+        goal->speed_j, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX, "speed_j");
     }
     if (goal->set_acc_j) {
-      acc_j = goal->acc_j;
+      acc_j = plugin_utils::clampWithWarning(
+        goal->acc_j, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX, "acc_j");
     }
     if (goal->set_cp) {
-      cp = goal->cp;
+      cp = plugin_utils::clampWithWarning(
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
     }
     this->commander_->movJIO(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_jio.cpp
+++ b/mg400_plugin/src/motion_api/mov_jio.cpp
@@ -142,15 +142,18 @@ void MovJIO::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t cp = -1;
     if (goal->set_speed_j) {
       speed_j = plugin_utils::clampWithWarning(
-        goal->speed_j, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX, "speed_j");
+        goal->speed_j, plugin_utils::SPEED_J_MIN, plugin_utils::SPEED_J_MAX,
+        this->node_logging_if_->get_logger(), "speed_j");
     }
     if (goal->set_acc_j) {
       acc_j = plugin_utils::clampWithWarning(
-        goal->acc_j, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX, "acc_j");
+        goal->acc_j, plugin_utils::ACC_J_MIN, plugin_utils::ACC_J_MAX,
+        this->node_logging_if_->get_logger(), "acc_j");
     }
     if (goal->set_cp) {
       cp = plugin_utils::clampWithWarning(
-        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX,
+        this->node_logging_if_->get_logger(), "cp");
     }
     this->commander_->movJIO(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -123,8 +123,9 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   try {
     angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
     RCLCPP_INFO(
-      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
-      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
+      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}",
+      angles[0] * 180.0 / M_PI, angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI,
+      angles[3] * 180.0 / M_PI);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
     // ErrorID 18: Inverse kinematics error with result out of working area
@@ -140,13 +141,17 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t acc_l = -1;
     int8_t cp = -1;
     if (goal->set_speed_l) {
-      speed_l = goal->speed_l;
+      speed_l = plugin_utils::clampWithWarning(
+        goal->speed_l, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX, "speed_l");
     }
     if (goal->set_acc_l) {
-      acc_l = goal->acc_l;
+      acc_l = plugin_utils::clampWithWarning(
+        goal->acc_l, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX, "acc_l");
     }
     if (goal->set_cp) {
-      cp = goal->cp;
+      cp =
+        plugin_utils::clampWithWarning(
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
     }
     this->commander_->movL(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,
@@ -162,8 +167,8 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
   const auto is_goal_reached = [&](
     const geometry_msgs::msg::Pose & pose,
     const geometry_msgs::msg::Pose & goal) -> bool {
-      const double tolerance_m = 5e-3;  // 5 mm
-      const double tolerance_rad = 1.74e-2;  // pi/2 *10e-2
+      const double tolerance_m = 5e-3;   // 5 mm
+      const double tolerance_rad = 1.74e-2;   // pi/2 *10e-2
       auto is_in_tolerance = [](
         const double val, const double tolerance) -> bool {
           return std::abs(val) < tolerance;

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -142,16 +142,19 @@ void MovL::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t cp = -1;
     if (goal->set_speed_l) {
       speed_l = plugin_utils::clampWithWarning(
-        goal->speed_l, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX, "speed_l");
+        goal->speed_l, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX,
+        this->node_logging_if_->get_logger(), "speed_l");
     }
     if (goal->set_acc_l) {
       acc_l = plugin_utils::clampWithWarning(
-        goal->acc_l, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX, "acc_l");
+        goal->acc_l, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX,
+        this->node_logging_if_->get_logger(), "acc_l");
     }
     if (goal->set_cp) {
       cp =
         plugin_utils::clampWithWarning(
-        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX,
+        this->node_logging_if_->get_logger(), "cp");
     }
     this->commander_->movL(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_lio.cpp
+++ b/mg400_plugin/src/motion_api/mov_lio.cpp
@@ -123,8 +123,9 @@ void MovLIO::execute(const std::shared_ptr<GoalHandle> goal_handle)
   try {
     angles = this->mg400_ik_util_.InverseKinematics(tool_vec);
     RCLCPP_INFO(
-      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}", angles[0] * 180.0 / M_PI,
-      angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI, angles[3] * 180.0 / M_PI);
+      this->node_logging_if_->get_logger(), "Joint angles = {%f, %f, %f, %f}",
+      angles[0] * 180.0 / M_PI, angles[1] * 180.0 / M_PI, angles[2] * 180.0 / M_PI,
+      angles[3] * 180.0 / M_PI);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(this->node_logging_if_->get_logger(), e.what());
     // ErrorID 18: Inverse kinematics error with result out of working area
@@ -140,13 +141,17 @@ void MovLIO::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t acc_l = -1;
     int8_t cp = -1;
     if (goal->set_speed_l) {
-      speed_l = goal->speed_l;
+      speed_l = plugin_utils::clampWithWarning(
+        goal->speed_l, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX, "speed_l");
     }
     if (goal->set_acc_l) {
-      acc_l = goal->acc_l;
+      acc_l = plugin_utils::clampWithWarning(
+        goal->acc_l, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX, "acc_l");
     }
     if (goal->set_cp) {
-      cp = goal->cp;
+      cp =
+        plugin_utils::clampWithWarning(
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
     }
     this->commander_->movLIO(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,

--- a/mg400_plugin/src/motion_api/mov_lio.cpp
+++ b/mg400_plugin/src/motion_api/mov_lio.cpp
@@ -142,16 +142,19 @@ void MovLIO::execute(const std::shared_ptr<GoalHandle> goal_handle)
     int8_t cp = -1;
     if (goal->set_speed_l) {
       speed_l = plugin_utils::clampWithWarning(
-        goal->speed_l, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX, "speed_l");
+        goal->speed_l, plugin_utils::SPEED_L_MIN, plugin_utils::SPEED_L_MAX,
+        this->node_logging_if_->get_logger(), "speed_l");
     }
     if (goal->set_acc_l) {
       acc_l = plugin_utils::clampWithWarning(
-        goal->acc_l, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX, "acc_l");
+        goal->acc_l, plugin_utils::ACC_L_MIN, plugin_utils::ACC_L_MAX,
+        this->node_logging_if_->get_logger(), "acc_l");
     }
     if (goal->set_cp) {
       cp =
         plugin_utils::clampWithWarning(
-        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX, "cp");
+        goal->cp, plugin_utils::CP_MIN, plugin_utils::CP_MAX,
+        this->node_logging_if_->get_logger(), "cp");
     }
     this->commander_->movLIO(
       this->tf_goal_.pose.position.x, this->tf_goal_.pose.position.y,


### PR DESCRIPTION
# 内容

-  MovJやMovLで，`set_speed_j`, `set_speed_l`などのフラグと一緒に`speed_j=0`などを送るとMG400で弾かれることの対策としてバリデーションを追加した
- MG400ノードのMovJやMovLのメッセージには，speed_jやspeed_lをセットしたいかのフラグset_spped_j, set_speed_lがあるため，それらフラグがtrueの時かつspeed_j, speed_lの値がレンジ外のときは警告を出してクランプするようにしてます