### PR TITLE
add ToolDI command

### DIFF
--- a/mg400_interface/README.md
+++ b/mg400_interface/README.md
@@ -19,6 +19,7 @@ This package provide interface library to connect with Dobot MG400 via TCP commu
 | :heavy_check_mark:   | PayLoad           |
 | :heavy_check_mark:   | DO                |
 | :heavy_check_mark:   | ToolDOExecute     |
+| :heavy_check_mark:   | ToolDI            |
 | :heavy_check_mark:   | AccJ              |
 | :heavy_check_mark:   | AccL              |
 | :heavy_check_mark:   | SpeedJ            |

--- a/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
+++ b/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
@@ -26,6 +26,7 @@
 #include <mg400_msgs/msg/do_index.hpp>
 #include <mg400_msgs/msg/do_status.hpp>
 #include <mg400_msgs/msg/error_id.hpp>
+#include <mg400_msgs/msg/tool_di_index.hpp>  // Ensure this include is present
 #include <mg400_msgs/msg/tool_do_index.hpp>
 #include <mg400_msgs/msg/tool.hpp>
 #include <mg400_msgs/msg/user.hpp>
@@ -54,6 +55,7 @@ private:
   using DOStatus = mg400_msgs::msg::DOStatus;
   using ErrorID = mg400_msgs::msg::ErrorID;
   using Tool = mg400_msgs::msg::Tool;
+  using ToolDIIndex = mg400_msgs::msg::ToolDIIndex;
   using ToolDOIndex = mg400_msgs::msg::ToolDOIndex;
   using User = mg400_msgs::msg::User;
 
@@ -107,6 +109,9 @@ public:
   void toolDOExecute(
     const ToolDOIndex::_index_type &,
     const DOStatus::_status_type &) const;
+
+  int toolDI(const ToolDIIndex &) const;
+  int toolDI(const ToolDIIndex::_index_type &) const;
 
   void accJ(const int);
 

--- a/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
+++ b/mg400_interface/include/mg400_interface/commander/dashboard_commander.hpp
@@ -26,7 +26,7 @@
 #include <mg400_msgs/msg/do_index.hpp>
 #include <mg400_msgs/msg/do_status.hpp>
 #include <mg400_msgs/msg/error_id.hpp>
-#include <mg400_msgs/msg/tool_di_index.hpp>  // Ensure this include is present
+#include <mg400_msgs/msg/tool_di_index.hpp>
 #include <mg400_msgs/msg/tool_do_index.hpp>
 #include <mg400_msgs/msg/tool.hpp>
 #include <mg400_msgs/msg/user.hpp>

--- a/mg400_interface/src/commander/dashboard_commander.cpp
+++ b/mg400_interface/src/commander/dashboard_commander.cpp
@@ -159,6 +159,24 @@ void DashboardCommander::toolDOExecute(
   this->evaluateResponse(this->sendAndWaitResponse(std::string(buf, cx)));
 }
 
+int DashboardCommander::toolDI(const ToolDIIndex & tool_di_index) const
+{
+  return this->toolDI(tool_di_index.index);
+}
+
+int DashboardCommander::toolDI(const ToolDIIndex::_index_type & tool_di_index) const
+{
+  static char buf[128];
+  static DashboardResponse response;
+  const int cx = snprintf(buf, sizeof(buf), "ToolDI(%u)", tool_di_index);
+  ResponseParser::parseResponse(
+    this->sendAndWaitResponse(std::string(buf, cx)), response);
+  if (response.error_id != 0) {
+    throw std::runtime_error("Dobot not return 0: " + std::to_string(response.error_id));
+  }
+  return ResponseParser::takeInt(response.ret_val);
+}
+
 void DashboardCommander::accJ(const int R)
 {
   static char buf[128];

--- a/mg400_interface/test/src/commander/test_dashboard_commander.cpp
+++ b/mg400_interface/test/src/commander/test_dashboard_commander.cpp
@@ -182,6 +182,17 @@ TEST_F(TestDashboardCommander, ToolDOExecute) {
       ToolDOIndex::D2, DOStatus::HIGH));
 }
 
+TEST_F(TestDashboardCommander, ToolDI) {
+  EXPECT_CALL(
+    mock, sendCommand(
+      StrEq("ToolDI(1)"))).Times(1);
+  EXPECT_CALL(
+    mock, recvResponse()).WillOnce(
+    Return("0,{0},ToolDI(1);"));
+  const int ret = commander->toolDI(1);
+  ASSERT_EQ(ret, 0);
+}
+
 TEST_F(TestDashboardCommander, AccJ) {
   EXPECT_CALL(
     mock, sendCommand(

--- a/mg400_msgs/msg/ToolDIIndex.msg
+++ b/mg400_msgs/msg/ToolDIIndex.msg
@@ -1,0 +1,3 @@
+uint32 D1 = 1
+uint32 D2 = 2
+uint32 index

--- a/mg400_msgs/srv/ToolDI.srv
+++ b/mg400_msgs/srv/ToolDI.srv
@@ -1,0 +1,4 @@
+mg400_msgs/ToolDIIndex index
+---
+uint8 result
+int32 error_id

--- a/mg400_node/README.md
+++ b/mg400_node/README.md
@@ -18,6 +18,7 @@ The following API interface plugin will be loaded by default
   - `SetCollisionLevel`
   - `SpeedFactor`
   - `ToolDOExecute`
+  - `ToolDI`
 - Motion API
   - `MoveJog`
   - `MovJ`

--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -47,6 +47,7 @@ private:
     "mg400_plugin::SetCollisionLevel",
     "mg400_plugin::SpeedFactor",
     "mg400_plugin::ToolDOExecute",
+    "mg400_plugin::ToolDI",
   };
 
   const std::vector<std::string> default_motion_api_plugins_ = {

--- a/mg400_plugin/dashboard_api_plugins.xml
+++ b/mg400_plugin/dashboard_api_plugins.xml
@@ -100,6 +100,11 @@
     <description>Execute end effector digital output</description>
   </class>
   <class
+      type="mg400_plugin::ToolDI"
+      base_class_type="mg400_plugin_base::DashboardApiPluginBase">
+    <description>Get digital input of end effector</description>
+  </class>
+  <class
       type="mg400_plugin::Tool"
       base_class_type="mg400_plugin_base::DashboardApiPluginBase">
     <description>Tool</description>

--- a/mg400_plugin/include/mg400_plugin/dashboard_api/tool_di.hpp
+++ b/mg400_plugin/include/mg400_plugin/dashboard_api/tool_di.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 HarvestX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __MG400_PLUGIN_DASHBOARD_API_TOOL_DO_EXECUTE_HPP__
+#define __MG400_PLUGIN_DASHBOARD_API_TOOL_DO_EXECUTE_HPP__
+
+#include <mg400_plugin_base/api_plugin_base.hpp>
+#include <mg400_msgs/srv/tool_di.hpp>
+
+namespace mg400_plugin
+{
+class ToolDI final
+  : public mg400_plugin_base::DashboardApiPluginBase
+{
+public:
+  using ServiceT = mg400_msgs::srv::ToolDI;
+  using CallbackT = std::function<
+    void (
+      const typename ServiceT::Request::SharedPtr,
+      typename ServiceT::Response::SharedPtr
+    )>;
+
+private:
+  rclcpp::Service<ServiceT>::SharedPtr srv_;
+
+public:
+  void configure(
+    const mg400_interface::DashboardCommander::SharedPtr,
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr,
+    const rclcpp::node_interfaces::NodeClockInterface::SharedPtr,
+    const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr,
+    const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr,
+    const rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr,
+    const mg400_interface::MG400Interface::SharedPtr) override;
+
+private:
+  void onServiceCall(
+    const ServiceT::Request::SharedPtr, ServiceT::Response::SharedPtr);
+};
+}  // namespace mg400_plugin
+#endif

--- a/mg400_plugin/src/dashboard_api/tool_di.cpp
+++ b/mg400_plugin/src/dashboard_api/tool_di.cpp
@@ -1,0 +1,74 @@
+// Copyright 2025 HarvestX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mg400_plugin/dashboard_api/tool_di.hpp"
+
+namespace mg400_plugin
+{
+
+void ToolDI::configure(
+  const mg400_interface::DashboardCommander::SharedPtr commander,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_if,
+  const rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_if,
+  const rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_if,
+  const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_if,
+  const rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr node_waitables_if,
+  const mg400_interface::MG400Interface::SharedPtr mg400_if)
+{
+  if (!this->configure_base(
+      commander, node_base_if, node_clock_if,
+      node_logging_if, node_services_if, node_waitables_if, mg400_if))
+  {
+    return;
+  }
+
+  using namespace std::placeholders;  // NOLINT
+  this->srv_ = rclcpp::create_service<ServiceT, CallbackT>(
+    this->node_base_if_,
+    this->node_services_if_,
+    "tool_di",
+    std::bind(&ToolDI::onServiceCall, this, _1, _2),
+    rclcpp::ServicesQoS().get_rmw_qos_profile(),
+    this->node_base_if_->get_default_callback_group());
+}
+
+void ToolDI::onServiceCall(
+  const ServiceT::Request::SharedPtr req,
+  ServiceT::Response::SharedPtr res)
+{
+  res->result = false;
+  res->error_id = -1;
+  if (this->mg400_interface_->ok()) {
+    try {
+      res->result = this->commander_->toolDI(req->index.index);
+      res->error_id = 0;
+    } catch (const mg400_interface::DashboardCommandException & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+      res->result = false;
+      res->error_id = ex.getDashboardResponse().error_id;
+    } catch (const std::runtime_error & ex) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), ex.what());
+    } catch (...) {
+      RCLCPP_ERROR(this->node_logging_if_->get_logger(), "Interface Error");
+    }
+  } else {
+    RCLCPP_ERROR(this->node_logging_if_->get_logger(), "MG400 is not connected");
+  }
+}
+}  // namespace mg400_plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  mg400_plugin::ToolDI,
+  mg400_plugin_base::DashboardApiPluginBase)


### PR DESCRIPTION
I have added support for the ToolDI command in TCP/IP mode.

In this mode, the value of the DI port attached to the tip of the MG400 is read.


<br>

The digital input (DI) allocations are as follows:

| index | Port |
| --- | ---  |
| 1 | DI17 |
| 2 | DI18 |

To read the DI value, use the `mg400_msgs/srv/ToolDI.srv service`  by specifying the index.

```bash
$ ros2 service call /mg400/tool_di mg400_msgs/srv/ToolDI "{'index': {'index':2}}"
requester: making request: mg400_msgs.srv.ToolDI_Request(index=mg400_msgs.msg.ToolDIIndex(index=2))

response:
mg400_msgs.srv.ToolDI_Response(result=1, error_id=0)
```

<br>

Tested environment
- DOBOT MG400
- Ubuntu 22.04 (6.8.0-59-generic)
- ROS-Humble
