### PR TITLE
Improving TCP communication connectivity

### DIFF
--- a/mg400_interface/package.xml
+++ b/mg400_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_interface</name>
-  <version>1.5.2</version>
+  <version>1.5.3</version>
   <description>MG400 Interface Library Packege.</description>
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>

--- a/mg400_interface/src/mg400_interface.cpp
+++ b/mg400_interface/src/mg400_interface.cpp
@@ -49,24 +49,36 @@ bool MG400Interface::activate()
   this->realtime_tcp_interface->init();
   this->motion_tcp_if_->init();
 
+  // Wait for the connection to be established.
   auto clock = rclcpp::Clock();
   const auto start = clock.now();
-
-  using namespace std::chrono_literals;  // NOLINT
-  if (rclcpp::sleep_for(2s) && !this->isConnected()) {
+  const auto timeout = rclcpp::Duration::from_seconds(10.0);
+  while ((clock.now() - start) < timeout) {
+    if (this->isConnected()) {
+      break;
+    }
+    rclcpp::sleep_for(500ms);
+    RCLCPP_INFO(this->getLogger(), "Connecting to DOBOT MG400 at %s ...", this->IP.c_str());
+  }
+  if (!this->isConnected()) {
     RCLCPP_ERROR(this->getLogger(), "Could not connect to DOBOT MG400.");
     this->deactivate();
     return false;
   }
 
-  if (this->isConnected() && !this->ok()) {
-    RCLCPP_WARN(
-      this->getLogger(),
-      "Connection established but no data sent from DOBOT MG400. Waiting...");
-    if (rclcpp::sleep_for(5s) && !this->ok()) {
-      this->deactivate();
-      return false;
+  // Wait for the data to be received.
+  const auto data_timeout = rclcpp::Duration::from_seconds(10.0);
+  const auto data_start = clock.now();
+  while ((clock.now() - data_start) < data_timeout) {
+    if (this->ok()) {
+      break;
     }
+    rclcpp::sleep_for(500ms);
+  }
+  if (!this->ok()) {
+    RCLCPP_ERROR(this->getLogger(), "Connection established but no data received.");
+    this->deactivate();
+    return false;
   }
 
   RCLCPP_INFO(this->getLogger(), "Connected to DOBOT MG400");

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -51,7 +51,7 @@ void DashboardTcpInterface::checkConnection()
   while (this->is_running_) {
     try {
       if (!this->tcp_socket_->isConnected()) {
-        this->tcp_socket_->connect(1s);
+        this->tcp_socket_->connect(10s);
       } else {
         rclcpp::sleep_for(1s);
         continue;

--- a/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/motion_tcp_interface.cpp
@@ -51,7 +51,7 @@ void MotionTcpInterface::checkConnection()
   while (this->is_running_) {
     try {
       if (!this->tcp_socket_->isConnected()) {
-        this->tcp_socket_->connect(1s);
+        this->tcp_socket_->connect(10s);
       } else {
         rclcpp::sleep_for(1s);
         continue;

--- a/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/realtime_feedback_tcp_interface.cpp
@@ -120,7 +120,7 @@ void RealtimeFeedbackTcpInterface::recvData()
     try {
       // Error: Connection error
       if (!this->tcp_socket_->isConnected()) {
-        this->tcp_socket_->connect(1s);
+        this->tcp_socket_->connect(10s);
         continue;
       }
 


### PR DESCRIPTION
## Problem

The TCP connection itself can be established, but no messages are coming from MG400, causing a timeout and the connection to be lost.



## Cause

Even if a TCP connection is established with the MG400, received data does not arrive immediately. Instead, it may take some time for the received data to arrive. This situation is particularly noticeable immediately after the MG400 is started up. The existing code retries the confirmation process after 5 seconds if the received data cannot be confirmed, but this time may not be sufficient to confirm the received data, resulting in a False value.



## Solution

- Implemented a retry process that sequentially checks TCP connection establishment and received data.
- Extended the timeout period compared to the existing code.
