### PR TITLE
Add feature publish empty error-id topic in no error

### DIFF
--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -78,6 +78,7 @@ private:
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr mg400_connected_pub_;
 
   bool connection_interrupted_;
+  bool allow_publish_empty_error_id_;
 
 public:
   MG400Node() = delete;

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -30,6 +30,9 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
     "motion_api_plugins", this->default_motion_api_plugins_);
   this->declare_parameter<std::string>("prefix", "");
 
+  // Allow empty error IDs to be delivered when errors are resolved.
+  this->declare_parameter<bool>("allow_publish_empty_error_id", true);
+
   if (this->get_parameter("auto_connect").as_bool()) {
     RCLCPP_INFO(this->get_logger(), "Auto connect is enabled");
     this->configure();
@@ -97,6 +100,12 @@ CallbackReturn MG400Node::on_configure(const State &)
     "error_id", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local());
 
   this->connection_interrupted_ = false;
+
+  this->allow_publish_empty_error_id_ =
+    this->get_parameter("allow_publish_empty_error_id").as_bool();
+  if (this->allow_publish_empty_error_id_) {
+    RCLCPP_INFO(this->get_logger(), "Allow publishing empty error IDs when errors are resolved.");
+  }
 
   if (this->get_parameter("auto_connect").as_bool()) {
     RCLCPP_INFO(this->get_logger(), "Try connecting to MG400 at %s ...", this->ip_address_.c_str());
@@ -215,6 +224,8 @@ void MG400Node::onRobotModeTimer()
 
 void MG400Node::onErrorTimer()
 {
+  static bool error_occurred_one_cycle_ago = false;
+
   if (!this->interface_->ok()) {
     return;
   }
@@ -222,6 +233,14 @@ void MG400Node::onErrorTimer()
   if (!this->interface_->realtime_tcp_interface->isRobotMode(
       mg400_msgs::msg::RobotMode::ERROR))
   {
+    if (this->allow_publish_empty_error_id_ && error_occurred_one_cycle_ago) {
+      auto msg = std::make_unique<mg400_msgs::msg::ErrorID>();
+      this->error_id_pub_->publish(std::move(msg));
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Published empty error ID message because the robot is resolved from error state.");
+    }
+    error_occurred_one_cycle_ago = false;
     return;
   }
 
@@ -253,6 +272,7 @@ void MG400Node::onErrorTimer()
     }
     RCLCPP_ERROR(this->get_logger(), ss.str().c_str());
     this->error_id_pub_->publish(std::move(msg));
+    error_occurred_one_cycle_ago = true;
   } catch (const std::runtime_error & ex) {
     RCLCPP_ERROR(this->get_logger(), ex.what());
     msg->controller.ids.emplace_back(-1);

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -94,7 +94,7 @@ CallbackReturn MG400Node::on_configure(const State &)
   this->robot_mode_pub_ = this->create_publisher<mg400_msgs::msg::RobotMode>(
     "robot_mode", rclcpp::SensorDataQoS());
   this->error_id_pub_ = this->create_publisher<mg400_msgs::msg::ErrorID>(
-    "error_id", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().durability_volatile());
+    "error_id", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local());
 
   this->connection_interrupted_ = false;
 


### PR DESCRIPTION
## Overview

I will implement a function that allows you to confirm that the MG400 has recovered from an error state simply by subscribing to the “error_id” topic. To do this, we will publish an empty “error_id” topic when the system recovers from an error state.


## Solution

- Add parameter "allow_publish_empty_error_id" to enable this function. Default is __true__.
- In the onErrorTimer handler, if the current status of MG400 does not indicate an error and the previous check indicated an error, publish an empty error_id topic.



## Test

1. Start up the MG400 main unit.

2. Launch MG400_ROS2.
```shell
ros2 launch mg400_bringup main.launch.py
```

3. Subscribe to the “error_id” topic using a command
```shell
ros2 topic echo /mg400/error_id
```

4. Press the emergency stop button.


5. Call "clear_error" service.
```shell
ros2 service call /mg400/clear_error mg400_msgs/srv/ClearError {}\ 
```

6. Confirm that the empty “error_id” topic is being published once.
```text
.
.
.
.
controller:
  ids:
  - 85
servo:
- ids: []
- ids: []
- ids: []
- ids: []
- ids: []

<---- call service "clear_error"

controller:
  ids: []
servo:
- ids: []
- ids: []
- ids: []
- ids: []
- ids: []
---

```
