### PR TITLE
Fixing multiple instances of transform-listener running

### DIFF
--- a/mg400_plugin/CMakeLists.txt
+++ b/mg400_plugin/CMakeLists.txt
@@ -20,7 +20,8 @@ foreach(TARGET ${TARGETS})
   ament_auto_add_library(
     ${PROJECT_NAME}_${TARGET}
     SHARED
-      ${MY_SRCS})
+      ${MY_SRCS}
+      src/tf_manager.cpp)
   pluginlib_export_plugin_description_file(
     mg400_plugin_base ${TARGET}_plugins.xml)
 endforeach()

--- a/mg400_plugin/include/mg400_plugin/motion_api/command_queue.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/command_queue.hpp
@@ -34,6 +34,7 @@
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
 #include <mg400_plugin/plugin_utils.hpp>
+#include <mg400_plugin/tf_manager.hpp>
 
 namespace mg400_plugin
 {
@@ -47,8 +48,6 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
 public:
   void configure(

--- a/mg400_plugin/include/mg400_plugin/motion_api/joint_mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/joint_mov_j.hpp
@@ -39,7 +39,7 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  
+
 public:
   void configure(
     const mg400_interface::MotionCommander::SharedPtr,

--- a/mg400_plugin/include/mg400_plugin/motion_api/joint_mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/joint_mov_j.hpp
@@ -39,9 +39,7 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-
+  
 public:
   void configure(
     const mg400_interface::MotionCommander::SharedPtr,

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_j.hpp
@@ -22,6 +22,7 @@
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
 #include <mg400_plugin/plugin_utils.hpp>
+#include <mg400_plugin/tf_manager.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
@@ -39,8 +40,6 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   geometry_msgs::msg::PoseStamped tf_goal_;
 

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_jio.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_jio.hpp
@@ -22,6 +22,7 @@
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
 #include <mg400_plugin/plugin_utils.hpp>
+#include <mg400_plugin/tf_manager.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
@@ -39,8 +40,6 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   geometry_msgs::msg::PoseStamped tf_goal_;
 

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_l.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_l.hpp
@@ -22,6 +22,7 @@
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
 #include <mg400_plugin/plugin_utils.hpp>
+#include <mg400_plugin/tf_manager.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
@@ -39,8 +40,6 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   geometry_msgs::msg::PoseStamped tf_goal_;
 

--- a/mg400_plugin/include/mg400_plugin/motion_api/mov_lio.hpp
+++ b/mg400_plugin/include/mg400_plugin/motion_api/mov_lio.hpp
@@ -22,6 +22,7 @@
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <mg400_plugin_base/api_plugin_base.hpp>
 #include <mg400_plugin/plugin_utils.hpp>
+#include <mg400_plugin/tf_manager.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
@@ -39,8 +40,6 @@ private:
   rclcpp_action::Server<ActionT>::SharedPtr action_server_;
 
   mg400_common::MG400IKUtil mg400_ik_util_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   geometry_msgs::msg::PoseStamped tf_goal_;
 

--- a/mg400_plugin/include/mg400_plugin/tf_manager.hpp
+++ b/mg400_plugin/include/mg400_plugin/tf_manager.hpp
@@ -27,7 +27,7 @@ namespace mg400_plugin
 
 /**
  * @brief Thread-safe singleton class for managing TF functionality
- * 
+ *
  * This class provides a centralized way to access TF buffer and listener,
  * preventing multiple instances from being created across different plugins.
  */
@@ -36,42 +36,42 @@ class TFManager final
 public:
   /**
    * @brief Get the singleton instance of TFManager
-   * 
+   *
    * @return TFManager& Reference to the singleton instance
    */
-  static TFManager& getInstance();
+  static TFManager & getInstance();
 
   /**
    * @brief Initialize the TF manager with a clock interface
-   * 
+   *
    * @param clock_if Clock interface for the TF buffer
    */
   void initialize(const rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_if);
 
   /**
    * @brief Get the TF buffer
-   * 
+   *
    * @return std::shared_ptr<tf2_ros::Buffer> Shared pointer to the TF buffer
    */
   std::shared_ptr<tf2_ros::Buffer> getBuffer();
 
   /**
    * @brief Get the TF listener
-   * 
+   *
    * @return std::shared_ptr<tf2_ros::TransformListener> Shared pointer to the TF listener
    */
   std::shared_ptr<tf2_ros::TransformListener> getListener();
 
   /**
    * @brief Check if the TF manager is initialized
-   * 
+   *
    * @return true if initialized, false otherwise
    */
   bool isInitialized() const;
 
   // Delete copy constructor and assignment operator to ensure singleton
-  TFManager(const TFManager&) = delete;
-  TFManager& operator=(const TFManager&) = delete;
+  TFManager(const TFManager &) = delete;
+  TFManager & operator=(const TFManager &) = delete;
 
 private:
   TFManager() = default;

--- a/mg400_plugin/include/mg400_plugin/tf_manager.hpp
+++ b/mg400_plugin/include/mg400_plugin/tf_manager.hpp
@@ -1,0 +1,89 @@
+// Copyright 2025 HarvestX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __MG400_PLUGIN_TF_MANAGER_HPP__
+#define __MG400_PLUGIN_TF_MANAGER_HPP__
+
+#include <memory>
+#include <mutex>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+namespace mg400_plugin
+{
+
+/**
+ * @brief Thread-safe singleton class for managing TF functionality
+ * 
+ * This class provides a centralized way to access TF buffer and listener,
+ * preventing multiple instances from being created across different plugins.
+ */
+class TFManager final
+{
+public:
+  /**
+   * @brief Get the singleton instance of TFManager
+   * 
+   * @return TFManager& Reference to the singleton instance
+   */
+  static TFManager& getInstance();
+
+  /**
+   * @brief Initialize the TF manager with a clock interface
+   * 
+   * @param clock_if Clock interface for the TF buffer
+   */
+  void initialize(const rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_if);
+
+  /**
+   * @brief Get the TF buffer
+   * 
+   * @return std::shared_ptr<tf2_ros::Buffer> Shared pointer to the TF buffer
+   */
+  std::shared_ptr<tf2_ros::Buffer> getBuffer();
+
+  /**
+   * @brief Get the TF listener
+   * 
+   * @return std::shared_ptr<tf2_ros::TransformListener> Shared pointer to the TF listener
+   */
+  std::shared_ptr<tf2_ros::TransformListener> getListener();
+
+  /**
+   * @brief Check if the TF manager is initialized
+   * 
+   * @return true if initialized, false otherwise
+   */
+  bool isInitialized() const;
+
+  // Delete copy constructor and assignment operator to ensure singleton
+  TFManager(const TFManager&) = delete;
+  TFManager& operator=(const TFManager&) = delete;
+
+private:
+  TFManager() = default;
+  ~TFManager() = default;
+
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  bool initialized_;
+
+  mutable std::mutex mutex_;
+};
+
+}  // namespace mg400_plugin
+
+#endif  // __MG400_PLUGIN_TF_MANAGER_HPP__

--- a/mg400_plugin/package.xml
+++ b/mg400_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_plugin</name>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <description>MG400 Pluginlib package.</description>
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>

--- a/mg400_plugin/src/motion_api/command_queue.cpp
+++ b/mg400_plugin/src/motion_api/command_queue.cpp
@@ -34,7 +34,7 @@ void CommandQueue::configure(
   }
 
   // Initialize TF manager if not already initialized
-  TFManager& tf_manager = TFManager::getInstance();
+  TFManager & tf_manager = TFManager::getInstance();
   if (!tf_manager.isInitialized()) {
     tf_manager.initialize(node_clock_if);
   }
@@ -404,7 +404,7 @@ bool CommandQueue::transformPoseToOrigin(
 {
   try {
     // Use the TFManager to get the transform
-    TFManager& tf_manager = TFManager::getInstance();
+    TFManager & tf_manager = TFManager::getInstance();
     auto tf_buffer = tf_manager.getBuffer();
     auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",

--- a/mg400_plugin/src/motion_api/command_queue.cpp
+++ b/mg400_plugin/src/motion_api/command_queue.cpp
@@ -33,9 +33,11 @@ void CommandQueue::configure(
     return;
   }
 
-  // setup for using tf
-  this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_clock_if_->get_clock());
-  this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
+  // Initialize TF manager if not already initialized
+  TFManager& tf_manager = TFManager::getInstance();
+  if (!tf_manager.isInitialized()) {
+    tf_manager.initialize(node_clock_if);
+  }
 
   using namespace std::placeholders;  // NOLINT
 
@@ -401,7 +403,10 @@ bool CommandQueue::transformPoseToOrigin(
   geometry_msgs::msg::PoseStamped & output_pose)
 {
   try {
-    auto transform = this->tf_buffer_->lookupTransform(
+    // Use the TFManager to get the transform
+    TFManager& tf_manager = TFManager::getInstance();
+    auto tf_buffer = tf_manager.getBuffer();
+    auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",
       input_pose.header.frame_id,
       rclcpp::Time(0)

--- a/mg400_plugin/src/motion_api/joint_mov_j.cpp
+++ b/mg400_plugin/src/motion_api/joint_mov_j.cpp
@@ -33,10 +33,6 @@ void JointMovJ::configure(
     return;
   }
 
-  // setup for using tf
-  this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_clock_if_->get_clock());
-  this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
-
   using namespace std::placeholders;  // NOLINT
 
   this->action_server_ =

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -32,9 +32,9 @@ void MovJ::configure(
   {
     return;
   }
-  
+
   // Initialize TF manager if not already initialized
-  TFManager& tf_manager = TFManager::getInstance();
+  TFManager & tf_manager = TFManager::getInstance();
   if (!tf_manager.isInitialized()) {
     tf_manager.initialize(node_clock_if);
   }
@@ -75,7 +75,7 @@ rclcpp_action::GoalResponse MovJ::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    TFManager& tf_manager = TFManager::getInstance();
+    TFManager & tf_manager = TFManager::getInstance();
     auto tf_buffer = tf_manager.getBuffer();
     const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",

--- a/mg400_plugin/src/motion_api/mov_j.cpp
+++ b/mg400_plugin/src/motion_api/mov_j.cpp
@@ -32,10 +32,12 @@ void MovJ::configure(
   {
     return;
   }
-
-  // setup for using tf
-  this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_clock_if_->get_clock());
-  this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
+  
+  // Initialize TF manager if not already initialized
+  TFManager& tf_manager = TFManager::getInstance();
+  if (!tf_manager.isInitialized()) {
+    tf_manager.initialize(node_clock_if);
+  }
 
   using namespace std::placeholders;  // NOLINT
 
@@ -73,7 +75,9 @@ rclcpp_action::GoalResponse MovJ::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    const auto transform = this->tf_buffer_->lookupTransform(
+    TFManager& tf_manager = TFManager::getInstance();
+    auto tf_buffer = tf_manager.getBuffer();
+    const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",
       goal->pose.header.frame_id, rclcpp::Time(0));
     tf2::doTransform(goal->pose, this->tf_goal_, transform);

--- a/mg400_plugin/src/motion_api/mov_jio.cpp
+++ b/mg400_plugin/src/motion_api/mov_jio.cpp
@@ -32,9 +32,9 @@ void MovJIO::configure(
   {
     return;
   }
-  
+
   // Initialize TF manager if not already initialized
-  TFManager& tf_manager = TFManager::getInstance();
+  TFManager & tf_manager = TFManager::getInstance();
   if (!tf_manager.isInitialized()) {
     tf_manager.initialize(node_clock_if);
   }
@@ -75,7 +75,7 @@ rclcpp_action::GoalResponse MovJIO::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    TFManager& tf_manager = TFManager::getInstance();
+    TFManager & tf_manager = TFManager::getInstance();
     auto tf_buffer = tf_manager.getBuffer();
     const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",

--- a/mg400_plugin/src/motion_api/mov_jio.cpp
+++ b/mg400_plugin/src/motion_api/mov_jio.cpp
@@ -32,10 +32,12 @@ void MovJIO::configure(
   {
     return;
   }
-
-  // setup for using tf
-  this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_clock_if_->get_clock());
-  this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
+  
+  // Initialize TF manager if not already initialized
+  TFManager& tf_manager = TFManager::getInstance();
+  if (!tf_manager.isInitialized()) {
+    tf_manager.initialize(node_clock_if);
+  }
 
   using namespace std::placeholders;  // NOLINT
 
@@ -73,7 +75,9 @@ rclcpp_action::GoalResponse MovJIO::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    const auto transform = this->tf_buffer_->lookupTransform(
+    TFManager& tf_manager = TFManager::getInstance();
+    auto tf_buffer = tf_manager.getBuffer();
+    const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",
       goal->pose.header.frame_id, rclcpp::Time(0));
     tf2::doTransform(goal->pose, this->tf_goal_, transform);

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -32,10 +32,12 @@ void MovL::configure(
   {
     return;
   }
-
-  // setup for using tf
-  this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_clock_if_->get_clock());
-  this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
+  
+  // Initialize TF manager if not already initialized
+  TFManager& tf_manager = TFManager::getInstance();
+  if (!tf_manager.isInitialized()) {
+    tf_manager.initialize(node_clock_if);
+  }
 
   using namespace std::placeholders;  // NOLINT
 
@@ -73,7 +75,9 @@ rclcpp_action::GoalResponse MovL::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    const auto transform = this->tf_buffer_->lookupTransform(
+    TFManager& tf_manager = TFManager::getInstance();
+    auto tf_buffer = tf_manager.getBuffer();
+    const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",
       goal->pose.header.frame_id, rclcpp::Time(0));
     tf2::doTransform(goal->pose, this->tf_goal_, transform);

--- a/mg400_plugin/src/motion_api/mov_l.cpp
+++ b/mg400_plugin/src/motion_api/mov_l.cpp
@@ -32,9 +32,9 @@ void MovL::configure(
   {
     return;
   }
-  
+
   // Initialize TF manager if not already initialized
-  TFManager& tf_manager = TFManager::getInstance();
+  TFManager & tf_manager = TFManager::getInstance();
   if (!tf_manager.isInitialized()) {
     tf_manager.initialize(node_clock_if);
   }
@@ -75,7 +75,7 @@ rclcpp_action::GoalResponse MovL::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    TFManager& tf_manager = TFManager::getInstance();
+    TFManager & tf_manager = TFManager::getInstance();
     auto tf_buffer = tf_manager.getBuffer();
     const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",

--- a/mg400_plugin/src/motion_api/mov_lio.cpp
+++ b/mg400_plugin/src/motion_api/mov_lio.cpp
@@ -34,7 +34,7 @@ void MovLIO::configure(
   }
 
   // Initialize TF manager if not already initialized
-  TFManager& tf_manager = TFManager::getInstance();
+  TFManager & tf_manager = TFManager::getInstance();
   if (!tf_manager.isInitialized()) {
     tf_manager.initialize(node_clock_if);
   }
@@ -75,7 +75,7 @@ rclcpp_action::GoalResponse MovLIO::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    TFManager& tf_manager = TFManager::getInstance();
+    TFManager & tf_manager = TFManager::getInstance();
     auto tf_buffer = tf_manager.getBuffer();
     const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",

--- a/mg400_plugin/src/motion_api/mov_lio.cpp
+++ b/mg400_plugin/src/motion_api/mov_lio.cpp
@@ -33,9 +33,11 @@ void MovLIO::configure(
     return;
   }
 
-  // setup for using tf
-  this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(node_clock_if_->get_clock());
-  this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
+  // Initialize TF manager if not already initialized
+  TFManager& tf_manager = TFManager::getInstance();
+  if (!tf_manager.isInitialized()) {
+    tf_manager.initialize(node_clock_if);
+  }
 
   using namespace std::placeholders;  // NOLINT
 
@@ -73,7 +75,9 @@ rclcpp_action::GoalResponse MovLIO::handle_goal(
 
   // tf (from goal->pose to this->tf_goal_)
   try {
-    const auto transform = this->tf_buffer_->lookupTransform(
+    TFManager& tf_manager = TFManager::getInstance();
+    auto tf_buffer = tf_manager.getBuffer();
+    const auto transform = tf_buffer->lookupTransform(
       this->mg400_interface_->realtime_tcp_interface->frame_id_prefix + "mg400_origin_link",
       goal->pose.header.frame_id, rclcpp::Time(0));
     tf2::doTransform(goal->pose, this->tf_goal_, transform);

--- a/mg400_plugin/src/tf_manager.cpp
+++ b/mg400_plugin/src/tf_manager.cpp
@@ -1,0 +1,57 @@
+// Copyright 2025 HarvestX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mg400_plugin/tf_manager.hpp"
+
+namespace mg400_plugin
+{
+
+TFManager& TFManager::getInstance()
+{
+  static TFManager instance;
+  return instance;
+}
+
+void TFManager::initialize(const rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_if)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  
+  if (initialized_) {
+    return;  // Already initialized
+  }
+
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(clock_if->get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  initialized_ = true;
+}
+
+std::shared_ptr<tf2_ros::Buffer> TFManager::getBuffer()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return tf_buffer_;
+}
+
+std::shared_ptr<tf2_ros::TransformListener> TFManager::getListener()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return tf_listener_;
+}
+
+bool TFManager::isInitialized() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return initialized_;
+}
+
+}  // namespace mg400_plugin

--- a/mg400_plugin/src/tf_manager.cpp
+++ b/mg400_plugin/src/tf_manager.cpp
@@ -17,7 +17,7 @@
 namespace mg400_plugin
 {
 
-TFManager& TFManager::getInstance()
+TFManager & TFManager::getInstance()
 {
   static TFManager instance;
   return instance;
@@ -26,7 +26,7 @@ TFManager& TFManager::getInstance()
 void TFManager::initialize(const rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_if)
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  
+
   if (initialized_) {
     return;  // Already initialized
   }


### PR DESCRIPTION
## Problem

When the current MG400_ROS2 is launched, multiple transform listeners are launched. This will be resolved.

```shell
$ ros2 node list
/mg400/mg400_node
/mg400/robot_state_publisher
/mg400/transform_listener_impl_621e639d9740
/mg400/transform_listener_impl_621e639f91f0
/mg400/transform_listener_impl_621e63a44970
/mg400/transform_listener_impl_621e63a6dd70
/mg400/transform_listener_impl_621e63a9a850
/mg400/transform_listener_impl_621e63af2830
/rviz2
/static_transform_publisher
/transform_listener_impl_60094375daf0
```



## Cause

In the current code, each plugin generates its own instances of tf_buffer and tf_listener. As a result, the transformer_listener process is launched multiple times, leading to high resource usage.



## Solution

- Imprement a singleton class that provides tf functionality. This class is thread-safe.
- Each plugin will obtain a reference to an instance of this class and access tf functionality through this instance.



## Test

1. Start up MG400 main unit and launch MG400_ROS2

```shell
$ ros2 launch mg400_bringup main.launch.py
```

2. Check the ROS node that is launched using the command.

```shell
$ ros2 node list
/mg400/mg400_node
/mg400/robot_state_publisher
/mg400/transform_listener_impl_5f8579f2d640
/rviz2
/transform_listener_impl_5a4911ac4670
```

From the output results, it can be confirmed that only one transform_listener is running under MG400.
