### PR TITLE
Fixing the TCP receive process

### DIFF
--- a/mg400_interface/include/mg400_interface/tcp_interface/tcp_socket_handler.hpp
+++ b/mg400_interface/include/mg400_interface/tcp_interface/tcp_socket_handler.hpp
@@ -61,6 +61,7 @@ public:
   bool isConnected() const;
   void send(const void *, uint32_t);
   bool recv(void *, uint32_t, const std::chrono::nanoseconds &);
+  bool recv(void *, uint32_t, uint32_t &, const std::chrono::nanoseconds &);
   std::string toString();
 };
 }  // namespace mg400_interface

--- a/mg400_interface/package.xml
+++ b/mg400_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_interface</name>
-  <version>1.5.3</version>
+  <version>1.5.4</version>
   <description>MG400 Interface Library Packege.</description>
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -86,9 +86,49 @@ void DashboardTcpInterface::disConnect()
 
 std::string DashboardTcpInterface::recvResponse()
 {
-  char buf[100] = {0};
-  this->tcp_socket_->recv(buf, sizeof(buf), 500ms);
-  RCLCPP_DEBUG(this->getLogger(), "recv: %s", std::string(buf).c_str());
-  return std::string(buf);
+  std::string response;
+  constexpr int kChunkSize = 128;  // Larger chunk for better efficiency
+  constexpr int kMaxResponseSize = 4096;  // Maximum response size limit
+
+  response.reserve(256);  // Pre-allocate memory to reduce reallocations
+
+  while (response.size() < kMaxResponseSize) {
+    try {
+      // Use stack buffer for temporary storage
+      std::array<char, kChunkSize> buffer{};
+
+      uint32_t bytes_received = 0;
+      this->tcp_socket_->recv(buffer.data(), kChunkSize, bytes_received, 500ms);
+
+      // Find semicolon using efficient search
+      auto * semicolon_pos = std::find(buffer.begin(), buffer.end(), ';');
+
+      if (bytes_received > 0) {
+        if (semicolon_pos != buffer.end()) {
+          // Found terminator - append up to and including semicolon
+          size_t bytes_to_copy = std::distance(buffer.begin(), semicolon_pos) + 1;
+          response.append(buffer.data(), bytes_to_copy);
+
+          RCLCPP_DEBUG(this->getLogger(), "recv: %s", response.c_str());
+          return response;
+        } else {
+          // No terminator found - append entire buffer
+          response.append(buffer.data(), bytes_received);
+        }
+      }
+
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(this->getLogger(), "Error receiving data: %s", e.what());
+      break;
+    }
+  }
+
+  if (response.size() >= kMaxResponseSize) {
+    RCLCPP_ERROR(this->getLogger(), "Response size exceeded maximum limit");
+  }
+
+  RCLCPP_DEBUG(this->getLogger(), "recv (incomplete): %s", response.c_str());
+  return response;
 }
+
 }  // namespace mg400_interface

--- a/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
+++ b/mg400_interface/src/tcp_interface/tcp_socket_handler.cpp
@@ -153,6 +153,43 @@ bool TcpSocketHandler::recv(void * buf, uint32_t len, const std::chrono::nanosec
   return true;
 }
 
+bool TcpSocketHandler::recv(
+  void * buf, uint32_t len, uint32_t & received_data_len,
+  const std::chrono::nanoseconds & timeout)
+{
+  uint8_t * tmp = reinterpret_cast<uint8_t *>(buf);
+  fd_set read_fds;
+  timeval tv = {0, 0};
+  received_data_len = 0;
+
+  while (len) {
+    FD_ZERO(&read_fds);
+    FD_SET(this->fd_, &read_fds);
+
+    tv.tv_sec = timeout.count() / static_cast<int>(1e9);
+    tv.tv_usec = (timeout.count() % static_cast<int>(1e9)) / static_cast<int>(1e3);
+    int err = ::select(this->fd_ + 1, &read_fds, nullptr, nullptr, &tv);
+    if (err < 0) {
+      this->disConnect();
+      throw TcpSocketException(this->toString() + std::string(" select() : ") + strerror(errno));
+    } else if (err == 0 || FD_ISSET(this->fd_, &read_fds) == 0) {
+      return false;
+    }
+    err = static_cast<int>(::read(fd_, tmp, len));
+    if (err < 0) {
+      this->disConnect();
+      throw TcpSocketException(this->toString() + std::string(" ::read() ") + strerror(errno));
+    } else if (err == 0) {
+      this->disConnect();
+      throw TcpSocketException(this->toString() + std::string(" tcp server has disconnected."));
+    }
+    len -= err;
+    tmp += err;
+    received_data_len += err;
+  }
+  return true;
+}
+
 std::string TcpSocketHandler::toString()
 {
   return this->ip_ + ":" + std::to_string(this->port_);


### PR DESCRIPTION
## Problem

The data received from MG400 has a semicolon “;” at the end, and the data up to that point is valid. In other words, the data size is variable.
The current code is designed to receive data that is shorter than a predetermined length, so if the data is longer than that, it may not be received correctly.



## Cause

In function "[mg400_interface::DashboardTcpInterface::recvResponse()](https://github.com/HarvestX/MG400_ROS2/blob/d71d7565fef06517cb32aef2f99a6ed5b6f738ad/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp#L87)", received data is treated as 100 bytes or less.



## Solution

- Implement function "mg400_interface::TcpSocketHandler::recv(...)" that can obtain the received data size.
- Improve function "mg400_interface::DashboardTcpInterface::recvResponse()" so that it receives while searching for semicolons.
