### PR TITLE
Fixing the TCP receive timeout behavior

### DIFF
--- a/mg400_interface/package.xml
+++ b/mg400_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_interface</name>
-  <version>1.5.4</version>
+  <version>1.5.5</version>
   <description>MG400 Interface Library Packege.</description>
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>

--- a/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
+++ b/mg400_interface/src/tcp_interface/dashboard_tcp_interface.cpp
@@ -100,6 +100,11 @@ std::string DashboardTcpInterface::recvResponse()
       uint32_t bytes_received = 0;
       this->tcp_socket_->recv(buffer.data(), kChunkSize, bytes_received, 500ms);
 
+      if (bytes_received == 0) {
+        // No data received, break the loop
+        break;
+      }
+
       // Find semicolon using efficient search
       auto * semicolon_pos = std::find(buffer.begin(), buffer.end(), ';');
 


### PR DESCRIPTION
## Problem

When the mg400_node is connected to the mg400 and the emergency stop button is pressed, followed by turning off the power, the mg400_node continuously displays the message “Tcp recv timeout.” This behavior differs from previous software versions. Previously, after the “Tcp recv timeout” message was displayed, the message “Robot not responded” appeared, and when auto_connect=true, the reconnection process was executed.



## Cause

This is because the "recvResponse()" function improved in this [PR](https://github.com/HarvestX/MG400_ROS2/pull/300) attempts to continue receiving even when there is a receive timeout (i.e., zero receive data).



## Solution

Added a process to exit the loop when the reception timeout occurs to "recvResponse()".



## Test

1. Start up the MG400 main unit.

2. Launch MG400_ROS2.
```shell
ros2 launch mg400_bringup main.launch.py
```

3. Press the emergency stop button
4. Turn off the MG400
5. Check the message
```
[mg400_node_exec-1] [INFO] [1755759336.078588624] [TcpClient]: send : GetErrorID()
[mg400_node_exec-1] [ERROR] [1755759336.584946345] [mg400.mg400_node]: Controller and Algorithm:
[mg400_node_exec-1] 	Hardware emergency stop button press or software emergency stop trigger
[mg400_node_exec-1] 
[mg400_node_exec-1] [INFO] [1755759336.585321821] [TcpClient]: send : GetErrorID()
[mg400_node_exec-1] [WARN] [1755759337.368460626] [Realtime Feedback Tcp Interface]: Tcp recv timeout
[mg400_node_exec-1] [WARN] [1755759338.369631440] [Realtime Feedback Tcp Interface]: Tcp recv timeout
[mg400_node_exec-1] [WARN] [1755759339.370795206] [Realtime Feedback Tcp Interface]: Tcp recv timeout
[mg400_node_exec-1] [WARN] [1755759340.371933826] [Realtime Feedback Tcp Interface]: Tcp recv timeout
[mg400_node_exec-1] [WARN] [1755759341.373198540] [Realtime Feedback Tcp Interface]: Tcp recv timeout
[mg400_node_exec-1] [ERROR] [1755759341.591358465] [mg400.mg400_node]: Robot not responded.
[mg400_node_exec-1] [ERROR] [1755759341.591525061] [mg400.mg400_node]: Connection to MG400 was interrupted
[mg400_node_exec-1] [WARN] [1755759341.591561400] [mg400.mg400_node]: Disconnected from MG400 at 192.168.1.6
[mg400_node_exec-1] [INFO] [1755759342.119652402] [Dashboard Tcp Interface]: Close connection.
[mg400_node_exec-1] [INFO] [1755759342.122882768] [Motion Tcp Interface]: Close connection.
[mg400_node_exec-1] [WARN] [1755759342.374351454] [Realtime Feedback Tcp Interface]: Tcp recv timeout
[mg400_node_exec-1] [INFO] [1755759342.374677098] [Realtime Feedback Tcp Interface]: Close connection.
[mg400_node_exec-1] [INFO] [1755759342.375045066] [mg400.mg400_node]: Try reconnecting in 5 seconds ...
[mg400_node_exec-1] [INFO] [1755759347.875800622] [MG400Interface]: Connecting to DOBOT MG400 at 192.168.1.6 ...
[mg400_node_exec-1] [INFO] [1755759348.376049030] [MG400Interface]: Connecting to DOBOT MG400 at 192.168.1.6 ...
[mg400_node_exec-1] [INFO] [1755759348.876336868] [MG400Interface]: Connecting to DOBOT MG400 at 192.168.1.6 ...
```

It can be confirmed that reconnection is being attempted.
