### PR TITLE
Add auto configure function to mg400_node

### DIFF
--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <memory>
 
+#include <lifecycle_msgs/msg/state.hpp>
 #include <mg400_msgs/msg/error_id.hpp>
 #include <mg400_msgs/msg/robot_mode.hpp>
 #include <std_msgs/msg/bool.hpp>
@@ -80,6 +81,9 @@ private:
 
   bool connection_interrupted_;
 
+  rclcpp::TimerBase::SharedPtr autostart_timer_;
+  std::atomic<bool> autostart_executed_{false};
+
 public:
   MG400Node() = delete;
   explicit MG400Node(const rclcpp::NodeOptions &);
@@ -101,6 +105,8 @@ private:
 
   void runTimer();
   void cancelTimer();
+
+  void handleAutoConfigure();
 };
 }  // namespace mg400_node
 

--- a/mg400_node/include/mg400_node/mg400_node.hpp
+++ b/mg400_node/include/mg400_node/mg400_node.hpp
@@ -81,8 +81,8 @@ private:
 
   bool connection_interrupted_;
 
-  rclcpp::TimerBase::SharedPtr autostart_timer_;
-  std::atomic<bool> autostart_executed_{false};
+  rclcpp::TimerBase::SharedPtr autoconfigure_timer_;
+  std::atomic<bool> autoconfigure_executed_{false};
 
 public:
   MG400Node() = delete;

--- a/mg400_node/package.xml
+++ b/mg400_node/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_node</name>
-  <version>2.4.0</version>
+  <version>2.5.0</version>
   <description>MG400 Node Package.</description>
-  <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
+  <maintainer email="veloute.de.jonquille@gmail.com">ynyBonfennil</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/mg400_node/package.xml
+++ b/mg400_node/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>lifecycle_msgs</depend>
   <depend>mg400_interface</depend>
   <depend>mg400_msgs</depend>
   <depend>mg400_plugin_base</depend>

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -47,7 +47,7 @@ MG400Node::~MG400Node()
 void MG400Node::handleAutoConfigure()
 {
   if (autostart_executed_.exchange(true)) {
-      return;
+    return;
   }
 
   if (autostart_timer_) {

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -30,10 +30,10 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
     "motion_api_plugins", this->default_motion_api_plugins_);
   this->declare_parameter<std::string>("prefix", "");
 
-  if (this->get_parameter("auto_connect").as_bool()) {
-    RCLCPP_INFO(this->get_logger(), "Auto connect is enabled");
-    this->configure();
-  }
+  this->declare_parameter("auto_configure", false);
+  autostart_timer_ = this->create_wall_timer(
+    std::chrono::milliseconds(100),
+    std::bind(&MG400Node::handleAutoConfigure, this));
 }
 
 MG400Node::~MG400Node()
@@ -41,6 +41,45 @@ MG400Node::~MG400Node()
   this->cancelTimer();
   if (this->interface_) {
     this->interface_->deactivate();
+  }
+}
+
+void MG400Node::handleAutoConfigure()
+{
+  if (autostart_executed_.exchange(true)) {
+      return;
+  }
+
+  if (autostart_timer_) {
+    autostart_timer_->cancel();
+  }
+
+  if (this->get_parameter("auto_connect").as_bool()) {
+    RCLCPP_INFO(this->get_logger(), "Auto connect is enabled");
+    this->configure();
+    return;
+  }
+
+  if (!this->get_parameter("auto_configure").as_bool()) {
+    return;
+  }
+
+  RCLCPP_INFO(this->get_logger(), "Attempting auto-configure...");
+  try {
+    auto state = this->configure();
+    if (state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+      RCLCPP_ERROR(
+        this->get_logger(), "Auto-configure failed (State ID: %d)",
+        state.id());
+      return;
+    } else {
+      RCLCPP_INFO(this->get_logger(), "Auto-configure successful");
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Auto-configure exception: %s",
+      e.what());
+    return;
   }
 }
 

--- a/mg400_node/src/mg400_node.cpp
+++ b/mg400_node/src/mg400_node.cpp
@@ -22,7 +22,9 @@ using namespace std::chrono_literals;   // NOLINT
 MG400Node::MG400Node(const rclcpp::NodeOptions & options)
 : rclcpp_lifecycle::LifecycleNode("mg400_node", options)
 {
+  this->declare_parameter<bool>("auto_configure", true);
   this->declare_parameter<bool>("auto_connect", true);
+  this->declare_parameter<int>("auto_configure_start_delay_msec", 100);
   this->declare_parameter<std::string>("ip_address", "192.168.1.6");
   this->declare_parameter<std::vector<std::string>>(
     "dashboard_api_plugins", this->default_dashboard_api_plugins_);
@@ -30,9 +32,19 @@ MG400Node::MG400Node(const rclcpp::NodeOptions & options)
     "motion_api_plugins", this->default_motion_api_plugins_);
   this->declare_parameter<std::string>("prefix", "");
 
-  this->declare_parameter("auto_configure", false);
-  autostart_timer_ = this->create_wall_timer(
-    std::chrono::milliseconds(100),
+  if (this->get_parameter("auto_configure").as_bool()) {
+    RCLCPP_INFO(
+      this->get_logger(), "Auto configure is enabled. Delaying for %ld msec.",
+      this->get_parameter("auto_configure_start_delay_msec").as_int());
+  }
+
+  if (this->get_parameter("auto_connect").as_bool()) {
+    RCLCPP_INFO(this->get_logger(), "Auto connect is enabled.");
+  }
+
+  autoconfigure_timer_ = this->create_wall_timer(
+    std::chrono::milliseconds(
+      this->get_parameter("auto_configure_start_delay_msec").as_int()),
     std::bind(&MG400Node::handleAutoConfigure, this));
 }
 
@@ -46,39 +58,33 @@ MG400Node::~MG400Node()
 
 void MG400Node::handleAutoConfigure()
 {
-  if (autostart_executed_.exchange(true)) {
+  if (autoconfigure_executed_.exchange(true)) {
     return;
   }
 
-  if (autostart_timer_) {
-    autostart_timer_->cancel();
+  if (autoconfigure_timer_) {
+    autoconfigure_timer_->cancel();
   }
 
-  if (this->get_parameter("auto_connect").as_bool()) {
-    RCLCPP_INFO(this->get_logger(), "Auto connect is enabled");
-    this->configure();
-    return;
-  }
-
-  if (!this->get_parameter("auto_configure").as_bool()) {
-    return;
-  }
-
-  RCLCPP_INFO(this->get_logger(), "Attempting auto-configure...");
-  try {
-    auto state = this->configure();
-    if (state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (this->get_parameter("auto_configure").as_bool()) {
+    RCLCPP_INFO(this->get_logger(), "Attempting auto-configure...");
+    try {
+      auto state = this->configure();
+      if (state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Auto-configure failed (State ID: %d)",
+          state.id());
+        return;
+      } else {
+        RCLCPP_INFO(this->get_logger(), "Auto-configure successful");
+      }
+    } catch (const std::exception & e) {
       RCLCPP_ERROR(
-        this->get_logger(), "Auto-configure failed (State ID: %d)",
-        state.id());
+        this->get_logger(), "Auto-configure exception: %s",
+        e.what());
       return;
-    } else {
-      RCLCPP_INFO(this->get_logger(), "Auto-configure successful");
     }
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(
-      this->get_logger(), "Auto-configure exception: %s",
-      e.what());
+  } else {
     return;
   }
 }


### PR DESCRIPTION
This pull request enhances the `mg400_node` package by introducing an auto-configuration feature with a configurable start delay, improving the node's startup behavior and configurability. The changes include new parameters, a timer-based mechanism for delayed auto-configuration, and improved logging for better diagnostics.

**Auto-configuration feature and startup improvements:**

* Added new parameters: `auto_configure` (enables/disables auto-configuration) and `auto_configure_start_delay_msec` (sets the delay before auto-configuration starts), both declared in the `MG400Node` constructor.
* Implemented a timer (`autoconfigure_timer_`) and an atomic flag (`autoconfigure_executed_`) to control and ensure the auto-configuration process runs only once after the specified delay. 
* Added the `handleAutoConfigure()` method, which attempts to configure the node after the delay, checks the resulting state, and provides logging for success or failure. 
* Modified the constructor to use the new timer-based mechanism for auto-configuration, replacing the previous immediate call to `configure()`.

**Dependencies and includes:**

* Added a dependency on `lifecycle_msgs` in `package.xml` and included its header in `mg400_node.hpp` to support lifecycle state checks. 