### PR TITLE
Enhance command processing by adding pose and joint state checks befo…

### DIFF
--- a/mg400_plugin/package.xml
+++ b/mg400_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_plugin</name>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <description>MG400 Pluginlib package.</description>
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>

--- a/mg400_plugin/src/motion_api/command_queue.cpp
+++ b/mg400_plugin/src/motion_api/command_queue.cpp
@@ -410,48 +410,75 @@ int CommandQueue::sendCommand(
       return true;
     };
 
-  int sent_command_count = 0;
+  auto is_same_as_current = [&](const mg400_msgs::msg::Command & command) -> bool
+    {
+      geometry_msgs::msg::PoseStamped transformed_pose;
+      switch (command.command_type) {
+        case mg400_msgs::msg::Command::CT_MOV_J:
+          if (!transformPoseToOrigin(command.mov_j_params.pose, transformed_pose)) {
+            return false;
+          }
+          return equal_poses(transformed_pose, current_pose);
 
-  for (const auto & command : commands) {
+        case mg400_msgs::msg::Command::CT_MOV_L:
+          if (!transformPoseToOrigin(command.mov_l_params.pose, transformed_pose)) {
+            return false;
+          }
+          return equal_poses(transformed_pose, current_pose);
+
+        case mg400_msgs::msg::Command::CT_JOINT_MOV_J:
+          return equal_joints(command.joint_mov_j_params.joint_angles, current_angles);
+
+        case mg400_msgs::msg::Command::CT_MOV_JIO:
+          if (!transformPoseToOrigin(command.mov_jio_params.pose, transformed_pose)) {
+            return false;
+          }
+          return equal_poses(transformed_pose, current_pose);
+
+        case mg400_msgs::msg::Command::CT_MOV_LIO:
+          if (!transformPoseToOrigin(command.mov_lio_params.pose, transformed_pose)) {
+            return false;
+          }
+          return equal_poses(transformed_pose, current_pose);
+
+        default:
+          return false;
+      }
+    };
+
+  size_t first_non_matching_index = 0;
+  while (first_non_matching_index < commands.size()) {
+    if (!is_same_as_current(commands[first_non_matching_index])) {
+      break;
+    }
+    ++first_non_matching_index;
+  }
+
+  int sent_command_count = 0;
+  for (size_t i = first_non_matching_index; i < commands.size(); ++i) {
+    const auto & command = commands[i];
     switch (command.command_type) {
       case mg400_msgs::msg::Command::CT_MOV_J:
-        if (equal_poses(command.mov_j_params.pose, current_pose) && sent_command_count == 0) {
-          break;
-        }
         sendMovJ(command.mov_j_params);
         sent_command_count++;
         break;
 
       case mg400_msgs::msg::Command::CT_MOV_L:
-        if (equal_poses(command.mov_l_params.pose, current_pose) && sent_command_count == 0) {
-          break;
-        }
         sendMovL(command.mov_l_params);
         sent_command_count++;
         break;
 
       case mg400_msgs::msg::Command::CT_JOINT_MOV_J:
-        if (equal_joints(command.joint_mov_j_params.joint_angles, current_angles) &&
-          sent_command_count == 0)
-        {
-          break;
-        }
         sendJointMovJ(command.joint_mov_j_params);
         sent_command_count++;
         break;
 
       case mg400_msgs::msg::Command::CT_MOV_JIO:
-        if (equal_poses(command.mov_jio_params.pose, current_pose) && sent_command_count == 0) {
-          break;
-        }
         sendMovJIO(command.mov_jio_params);
         sent_command_count++;
         break;
 
       case mg400_msgs::msg::Command::CT_MOV_LIO:
-        if (equal_poses(command.mov_lio_params.pose, current_pose) && sent_command_count == 0) {
-          break;
-        }
         sendMovLIO(command.mov_lio_params);
         sent_command_count++;
         break;


### PR DESCRIPTION
  ## Summary
  This PR updates `CommandQueue::sendCommand` to skip commands at the head of the queue when they match
  the current robot state.

  ## Changes
  - Added a check to see whether each command matches the current state
  - Skips consecutive matching commands from the start of the queue
  - Sends commands only from the first non-matching command

  ## Reason
  When a request contains only move commands that are the same as the current state, no actual motion
  happens.
  As a result, the robot does not become `enable`, and the process ends in an error.