### PR TITLE
Fix/command-queue-tolerance

### DIFF
--- a/mg400_plugin/package.xml
+++ b/mg400_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mg400_plugin</name>
-  <version>1.8.1</version>
+  <version>1.8.2</version>
   <description>MG400 Pluginlib package.</description>
   <maintainer email="m12watanabe1a@gmail.com">m12watanabe1a</maintainer>
   <license>Apache-2.0</license>

--- a/mg400_plugin/src/motion_api/command_queue.cpp
+++ b/mg400_plugin/src/motion_api/command_queue.cpp
@@ -83,7 +83,7 @@ rclcpp_action::GoalResponse CommandQueue::handle_goal(
 }
 
 rclcpp_action::CancelResponse CommandQueue::handle_cancel(
-  const std::shared_ptr<GoalHandle>)
+  const std::shared_ptr<GoalHandle>/*unused*/)
 {
   RCLCPP_INFO(
     this->node_logging_if_->get_logger(), "Received request to cancel goal");
@@ -400,7 +400,7 @@ int CommandQueue::sendCommand(
 
   auto equal_joints = [](const std::array<double, 4> & a,
       const std::array<double, 4> & b,
-      double tol = 1e-3) -> bool
+      double tol = 2e-3) -> bool
     {
       for (size_t i = 0; i < a.size(); ++i) {
         if (std::fabs(a[i] - b[i]) > tol) {


### PR DESCRIPTION
## PR Description

  - Increase joint comparison tolerance in command_queue.cpp (1e-3 -> 2e-3).
  - Mark unused cancel callback goal handle parameter.
  - Bump mg400_plugin version to 1.8.2.